### PR TITLE
improved image height checking

### DIFF
--- a/src/app/sharedWafrn/wafrn-media/wafrn-media.component.ts
+++ b/src/app/sharedWafrn/wafrn-media/wafrn-media.component.ts
@@ -40,7 +40,7 @@ export class WafrnMediaComponent implements OnInit {
 
 
   imgLoaded() {
-    if(this.wafrnMedia.nativeElement.offsetHeight > 850) {
+    if(this.wafrnMedia.nativeElement.offsetHeight/this.wafrnMedia.nativeElement.offsetWidth > 2) {
       this.nsfw = true;
     }
   }


### PR DESCRIPTION
The current method of checking image height is not accurate.
This should improve it by checking the aspect ratio instead.