### PR TITLE
Fixed banner in registry for Mobile, added some margin to the media component

### DIFF
--- a/src/app/components/wafrn-media/wafrn-media.component.html
+++ b/src/app/components/wafrn-media/wafrn-media.component.html
@@ -1,4 +1,4 @@
-<mat-card *ngIf="data" class="parent">
+<mat-card *ngIf="data" class="parent mt-1">
   <img
     #wafrnMedia
     *ngIf="

--- a/src/app/pages/register/register.component.html
+++ b/src/app/pages/register/register.component.html
@@ -12,7 +12,7 @@
     >
   </div>
 
-  <button mat-flat-button color="warn" class="w-full" *ngIf="manuallyReview">
+  <button mat-flat-button color="warn" class="w-full h-full py-2" *ngIf="manuallyReview">
     An administrator will review your profile before you can join. This process
     can take a few hours.
   </button>


### PR DESCRIPTION
Hi! I was looking at Wafrn and saw this:

![image](https://github.com/gabboman/wafrn/assets/81446590/eaef58df-79f5-4b6c-8cbe-d75c794b2345)

So.. I figured out that I could make a PR!

Now it looks like this:

![image](https://github.com/gabboman/wafrn/assets/81446590/9f2b6ee0-5453-4020-b145-5175bf8a884c)

Also added some padding to the media component, because when someone added two audios in a row it looked like this:
![image](https://github.com/gabboman/wafrn/assets/81446590/41dfeb5b-35e6-4e45-88cd-1fac12dc3ff5)

And now: 
![image](https://github.com/gabboman/wafrn/assets/81446590/8cfbc6b3-503f-49f5-a011-5c3934a4c247)


