### PR TITLE
Updated avatar button styling

### DIFF
--- a/packages/frontend/src/app/pages/register/register.component.html
+++ b/packages/frontend/src/app/pages/register/register.component.html
@@ -102,13 +102,18 @@
 
       </mat-select>
     </mat-form-field>
-    <div class="pt-2 px-3 border-round-md" style="border: 1px solid #999">
+    <div class="pt-2 px-3 pb-2 border-round-md" style="border: 1px solid #999">
       <label for="avatar" class="block text-900 font-medium mb-2">Upload your avatar</label>
-      <input formControlName="avatar" id="avatar" type="file" accept="image/jpeg,image/png,image/webp,image/gif"
-        (change)="imgSelected($event)" pTooltip="Select your avatar" tooltipPosition="top" pInputText
-        class="w-full mb-3" />
+      <div class="flex flex-row align-content-center">
+      <button type="button" mat-stroked-button color="primary" (click)="avatarInput.click()">
+        <fa-icon [icon]="faUpload" class="m-1"></fa-icon>Choose File</button>
+        <input #avatarInput formControlName="avatar" id="avatar" type="file" accept="image/jpeg,image/png,image/webp,image/gif"
+        hidden (change)="imgSelected($event)" />
+        <p class="m-auto ml-1">{{ selectedFileName }}</p>
+      </div>
     </div>
-    <button color="primary" mat-flat-button color="primary" extended [disabled]="loading || !loginForm.valid"
+    
+    <button color="primary" mat-flat-button extended [disabled]="loading || !loginForm.valid"
       class="w-full border-round-md mt-4">
       <fa-icon [icon]="faUser"></fa-icon>
       Register

--- a/packages/frontend/src/app/pages/register/register.component.ts
+++ b/packages/frontend/src/app/pages/register/register.component.ts
@@ -7,7 +7,7 @@ import {
 import { LoginService } from 'src/app/services/login.service';
 import { MessageService } from 'src/app/services/message.service';
 
-import { faUser, faEye, faEyeSlash } from '@fortawesome/free-solid-svg-icons';
+import { faEye, faEyeSlash, faUpload, faUser } from '@fortawesome/free-solid-svg-icons';
 import { EnvironmentService } from 'src/app/services/environment.service';
 
 @Component({
@@ -25,10 +25,13 @@ export class RegisterComponent {
   faUser = faUser;
   faEye = faEye;
   faEyeSlash = faEyeSlash;
+  faUpload = faUpload;
 
   minimumRegistrationDate: Date;
   minDate: Date;
   img: File | null = null;
+  selectedFileName: string = '';
+
 
   loginForm = new UntypedFormGroup({
     email: new UntypedFormControl('', [Validators.required, Validators.email]),
@@ -90,6 +93,7 @@ export class RegisterComponent {
   imgSelected(ev: Event) {
     const el = ev.target as HTMLInputElement;
     if (el.files?.[0]) {
+      this.selectedFileName = el.files[0].name;
       this.img = el.files[0];
     }
   }


### PR DESCRIPTION
Updated the avatar upload feature by replacing the default input field with a Material button for a more consistent UI design. Users can also view the selected file name beside the button, improving clarity and user experience.

![image](https://github.com/user-attachments/assets/351ca637-f148-4a12-9601-13ee81610f52)

![image](https://github.com/user-attachments/assets/f897aced-4782-471c-8eee-d871c8e513c7)


