### PR TITLE
Fix proxy target to prevent ECONNREFUSED error in Node 17+

### DIFF
--- a/packages/backend/routes/activitypub/well-known.ts
+++ b/packages/backend/routes/activitypub/well-known.ts
@@ -162,7 +162,7 @@ function wellKnownRoutes(app: Application) {
       {
         relation: ['delegate_permission/common.handle_all_urls'],
         target: {
-          namespace: 'wafrn-rn',
+          namespace: 'android_app',
           package_name: 'dev.djara.wafrn_rn',
           sha256_cert_fingerprints: [
             '09:1A:D9:44:84:3E:18:0C:43:22:ED:E2:02:A7:33:09:4C:DC:07:DD:1A:CD:51:52:3F:E8:13:EA:E9:04:F4:87'

--- a/packages/frontend/src/app/pages/privacy/privacy.component.html
+++ b/packages/frontend/src/app/pages/privacy/privacy.component.html
@@ -29,11 +29,11 @@
     <p class="mb-3">
       We will also store your registration IP, your last login ip and the ip
       that you use when you upload a media like pic or video, so if you post
-      something ilegal we can comply with the authorities
+      something illegal we can comply with the authorities.
     </p>
     <p class="mb-3">
       If your account does not get activated in a period between a month and a
-      year it might get deleted
+      year it might get deleted.
     </p>
     <p class="mb-3">
       If you want to get all the data we have about you, or there is any problem

--- a/packages/frontend/src/proxy.conf.json
+++ b/packages/frontend/src/proxy.conf.json
@@ -1,6 +1,6 @@
 {
   "/api": {
-    "target": "http://localhost:3001/",
+    "target": "http://127.0.0.1:3001",
     "secure": false
   }
 }


### PR DESCRIPTION
Starting with Node version 17, resolving http://localhost:<port> doesn’t always map to http://127.0.0.1:<port>, depending on the machine's configuration. This can lead to ECONNREFUSED errors when using a proxy that targets localhost. To prevent this, the proxy target has been updated from http://localhost:<port> to http://127.0.0.1:<port>.
This change should ensure consistent connection across different environments.

Reference: https://v17.angular.io/guide/build#proxying-to-a-backend-server
![image](https://github.com/user-attachments/assets/d64444c1-7987-4463-9e73-dda39f0d2847)
