### PR TITLE
Center nsfw overlay text over video and image

### DIFF
--- a/packages/frontend/src/app/components/wafrn-media/wafrn-media.component.html
+++ b/packages/frontend/src/app/components/wafrn-media/wafrn-media.component.html
@@ -1,29 +1,35 @@
 <div #media>
   <mat-card *ngIf="data" class="overflow-hidden mt-1" (click)="showPicture()">
-    <b class="img-cw-text" *ngIf="nsfw">This contains sensitive content. Click to display</b>
-
     <div (keyup)="showPicture()" class="img-container media-description bg-black-alpha-10">
-      <img *ngIf="
-      ((!extensionsToHideImgTag.includes(extension)) ||
-      mimeType === 'UNKNOWN') && !mimeType.startsWith('video')
-    " [src]="displayUrl" [alt]="data.description" role="none" loading="lazy" [ngClass]="{
+      <div class="img-video-container">
+        <b class="img-cw-text" *ngIf="nsfw">This contains sensitive content. Click to display</b>
+
+        <img *ngIf="
+        ((!extensionsToHideImgTag.includes(extension)) ||
+        mimeType === 'UNKNOWN') && !mimeType.startsWith('video')
+      " [src]="displayUrl" [alt]="data.description" role="none" loading="lazy" [ngClass]="{
+        'nsfw': nsfw,
+        'displayed-image': !nsfw
+      }" />
+
+        <video (play)="showPicture()" preload="metadata" [ngClass]="{
       'nsfw': nsfw,
       'displayed-image': !nsfw
-    }" />
-      <video (play)="showPicture()" preload="metadata" [ngClass]="{
-    'nsfw': nsfw,
-    'displayed-image': !nsfw
-  }" *ngIf="mimeType.startsWith('video')" controls>
-        <source [src]="displayUrl" [type]="mimeType" />
-      </video>
+    }" *ngIf="mimeType.startsWith('video')" controls>
+          <source [src]="displayUrl" [type]="mimeType" />
+        </video>
+      </div>
+
+
       <div *ngIf="!nsfw && mimeType.startsWith('pdf')">
         <a [href]="displayUrl" target="_blank">Click here to see the PDF file that is embedded in this post</a>
       </div>
+
       <audio *ngIf="!nsfw && mimeType.startsWith('audio')" controls>
         <source [src]="displayUrl" [type]="mimeType" />
       </audio>
-      <div *ngIf="data.description" class="px-2 " [innerText]="data.description"></div>
-    </div>
 
+      <div *ngIf="data.description" class="px-2" [innerText]="data.description"></div>
+    </div>
   </mat-card>
 </div>

--- a/packages/frontend/src/app/components/wafrn-media/wafrn-media.component.scss
+++ b/packages/frontend/src/app/components/wafrn-media/wafrn-media.component.scss
@@ -1,4 +1,5 @@
-img, video {
+img,
+video {
   max-width: 100%;
   width: 100%;
 }
@@ -18,6 +19,10 @@ img, video {
     filter: grayscale(1) contrast(0%);
     background-color: grey;
   }
+}
+
+.img-video-container {
+  position: relative;
 }
 
 .img-cw-text {


### PR DESCRIPTION

Changes that are made:

Added a container which holds both video and img section and centered the Nsfw Text to center 

Desktop 

<img width="1440" alt="Screenshot 2024-11-10 at 22 44 34" src="https://github.com/user-attachments/assets/abe6e26a-955b-471c-8e9f-59bf552da9c8">

Mobile 

<img width="214" alt="Screenshot 2024-11-10 at 23 12 49" src="https://github.com/user-attachments/assets/9aaf68da-e829-4a35-9cdb-7abd4aa300f7">

