### PR TITLE
Various UI/UX Tweaks and other polish

### DIFF
--- a/packages/frontend/src/app/components/emoji-react/emoji-react.component.scss
+++ b/packages/frontend/src/app/components/emoji-react/emoji-react.component.scss
@@ -5,4 +5,6 @@
     overflow-x: hidden;
     overflow-y: scroll;
     background-color: var(--mdc-filled-text-field-container-color);
+    border: 1px solid #888;
+    border-radius: 8px;
 }

--- a/packages/frontend/src/app/components/new-editor/new-editor.component.scss
+++ b/packages/frontend/src/app/components/new-editor/new-editor.component.scss
@@ -80,6 +80,23 @@ app-media-preview {
   z-index: 999;
   overflow-x: hidden;
   overflow-y: scroll;
-  background-color: #1d1b1e;
-  ;
+  background-color: #1d1b1e;  
+  border-radius: 8px;
+  border: 1px solid #888;	
+  padding: 8px;
 }
+
+/* Not sure if this is how to do it but lmao */
+.suggestionsMenu > div {
+	margin-block: 4px;
+}
+
+.suggestionsMenu > div > app-avatar-small {
+	margin-right: 4px;
+}
+
+/* This doesn't work and I cannot figure out the correct class to target */
+/* see frontend/src/styles.scss L387 instead */
+/* .mat-mdc-dialog-inner-container > .mat-mdc-dialog-surface { */
+/*     padding: 20px; */
+/* } */

--- a/packages/frontend/src/app/components/post-fragment/post-fragment.component.html
+++ b/packages/frontend/src/app/components/post-fragment/post-fragment.component.html
@@ -65,7 +65,7 @@
       <button [disabled]=" reactionLoading" [ngClass]="{
       reacted: emoji.includesMe,
       blurry: (fragment.content_warning || fragment.muted_words_cw) && showCw
-    }" (mousedown)="toggleEmojiReact(emoji)" mat-stroked-button matTooltipTouchGestures="on"
+    }" (mousedown)="toggleEmojiReact(emoji)" mat-raised-button matTooltipTouchGestures="on"
         [matTooltip]="emoji.tooltip">
         @if (emoji.img) {
         <img class="post-emoji" [src]="emoji.img" [alt]="emoji.content" />
@@ -76,9 +76,9 @@
         }
       </button>
       } @else {
-      <span [ngClass]="{
+      <button [ngClass]="{
         blurry: (fragment.content_warning || fragment.muted_words_cw) && showCw
-      }" class="p-3" [matTooltip]="emoji.tooltip ">
+      }" class="p-3" [matTooltip]="emoji.tooltip " mat-stroked-button>
         @if (emoji.img) {
         <img class="post-emoji" [src]="emoji.img" [alt]="emoji.content" />
         } @else {
@@ -86,7 +86,7 @@
         } @if (emoji.users.length !== 1) {
         <span> {{ emoji.users.length }}</span>
         }
-      </span>
+      </button>
       }
 
       }

--- a/packages/frontend/src/app/components/post-fragment/post-fragment.component.scss
+++ b/packages/frontend/src/app/components/post-fragment/post-fragment.component.scss
@@ -11,3 +11,9 @@
   background-color: #555;
 }
 
+#emoji-reactions > button {
+    margin-right: 6px;
+    margin-bottom: 4px;
+    /* what professional engineering right here */
+    vertical-align: -5.1%;
+}

--- a/packages/frontend/src/app/components/post-fragment/post-fragment.component.scss
+++ b/packages/frontend/src/app/components/post-fragment/post-fragment.component.scss
@@ -8,7 +8,8 @@
 }
 
 .reacted {
-  background-color: #555;
+  background-color: rgba(#D6BAFF, 0.25);
+  color: white;
 }
 
 #emoji-reactions > button {

--- a/packages/frontend/src/styles.scss
+++ b/packages/frontend/src/styles.scss
@@ -48,10 +48,14 @@ $editor-buttons: #ffffffde;
 }
 
 // dirty hack because bug regarding the editor
-/* not sure what this fixed but site seems fine without it */
-/* on desktop & mobile */
-/* .cdk-overlay-pane.mat-mdc-dialog-panel { */
-/*   max-width: 100% !important; */
+.cdk-overlay-pane.mat-mdc-dialog-panel {
+  max-width: 100% !important;
+}
+
+/* This little experiment sadly didn't work */
+/* .cdk-overlay-pane.mat-mdc-dialog-panel:not(app-new-editor) > * { */
+/*   margin: auto; */
+/*   max-width: 400px; */
 /* } */
 
 
@@ -384,7 +388,6 @@ pre {
   overflow-x: scroll
 }
 
-/* .mat-mdc-dialog-inner-container > .mat-mdc-dialog-surface:has(app-new-editor) { */
 .mat-mdc-dialog-inner-container > .mat-mdc-dialog-surface {
     padding: 20px;
 }

--- a/packages/frontend/src/styles.scss
+++ b/packages/frontend/src/styles.scss
@@ -384,6 +384,7 @@ pre {
   overflow-x: scroll
 }
 
-.mat-mdc-dialog-inner-container > .mat-mdc-dialog-surface:has(app-new-editor) {
+/* .mat-mdc-dialog-inner-container > .mat-mdc-dialog-surface:has(app-new-editor) { */
+.mat-mdc-dialog-inner-container > .mat-mdc-dialog-surface {
     padding: 20px;
 }

--- a/packages/frontend/src/styles.scss
+++ b/packages/frontend/src/styles.scss
@@ -48,9 +48,12 @@ $editor-buttons: #ffffffde;
 }
 
 // dirty hack because bug regarding the editor
-.cdk-overlay-pane.mat-mdc-dialog-panel {
-  max-width: 100% !important;
-}
+/* not sure what this fixed but site seems fine without it */
+/* on desktop & mobile */
+/* .cdk-overlay-pane.mat-mdc-dialog-panel { */
+/*   max-width: 100% !important; */
+/* } */
+
 
 a,
 a:visited,
@@ -285,9 +288,8 @@ blockquote {
   margin-bottom: 4px;
   border: 1px solid #888;
   overflow: hidden;
-  // TODO: fix this hack.
-  height: 0px;
-  padding-bottom: 85px;
+  flex-shrink: 0;
+  max-height: 128px;
 }
 
 .ql-size-small {
@@ -380,4 +382,8 @@ mat-paginator,
 
 pre {
   overflow-x: scroll
+}
+
+.mat-mdc-dialog-inner-container > .mat-mdc-dialog-surface:has(app-new-editor) {
+    padding: 20px;
 }


### PR DESCRIPTION
This PR does a lot, to break it down:

- Re-style emoji reactions to be more consistent, whilst still differentiating wafrn reactions and external ones. Also add margin around the buttons and re-align to be consistent `[not tested with more than 3 lines of emojis but should be fine]`
- Touch up `suggestionMenu` and the emoji react popup to have a 1px grey border (as per other elements) and touch up margins/paddings within those popups
- give all modal dialogs 20px of padding to avoid overflow (among a myriad of other things)
- removed and fixed a hacky workaround where quotes would sometimes be cut off vertically. This was because the `flex-shrink: 1` property was applied to quotes, probably inherited. The new settings have a 128px max-height and set `flex-shrink` to `0`.

This PR will be updated over time as I make more changes, as such it's marked as a draft for now; Though feedback and reviews are appreciated :)

PS: I'll add some comparison screenshots soon