### PR TITLE
Wafrn: The Cards and Colours update

### DIFF
--- a/packages/frontend/src/app/components/navigation-menu/navigation-menu.component.ts
+++ b/packages/frontend/src/app/components/navigation-menu/navigation-menu.component.ts
@@ -41,7 +41,9 @@ import {
   faHourglass,
   faBellSlash,
   faIcons,
-  faSkull
+  faSkull,
+  faFileEdit,
+  faPaintbrush
 } from '@fortawesome/free-solid-svg-icons';
 import { MenuItem } from 'src/app/interfaces/menu-item';
 import { MatDialog } from '@angular/material/dialog';
@@ -331,16 +333,16 @@ export class NavigationMenuComponent implements OnInit, OnDestroy {
         badge: this.followsAwaitingAproval,
         items: [
           {
-            label: 'Awaiting follows',
-            title: 'awaiting follows',
+            label: 'Manage followers',
+            title: 'Manage followers',
             badge: this.followsAwaitingAproval,
             icon: faUser,
             command: () => this.hideMenu(),
             routerLink: '/blog/' + this.jwtService.getTokenData().url + '/followers'
           },
           {
-            label: 'Edit profile',
-            title: 'Edit profile',
+            label: 'Profile options',
+            title: 'Profile options',
             icon: faUserEdit,
             command: () => {
               this.hideMenu();
@@ -351,7 +353,7 @@ export class NavigationMenuComponent implements OnInit, OnDestroy {
           {
             label: 'Edit my theme',
             title: 'Edit my theme',
-            icon: faUserEdit,
+            icon: faPaintbrush,
             command: () => {
               this.hideMenu();
             },

--- a/packages/frontend/src/app/components/new-editor/new-editor.component.html
+++ b/packages/frontend/src/app/components/new-editor/new-editor.component.html
@@ -75,17 +75,6 @@
       (blur)="editorFocusedOut()" (focus)="editorFocusedIn()" matNativeControl></textarea>
   </mat-form-field>
 </form>
-<section id="privacy-messages">
-  <p *ngIf="privacy === 10" class="my-2">
-    Attention! ADMINS of both your instance, and the target instance can read
-    the DMs.
-  </p>
-  <p *ngIf="privacy === 3" class="my-2">
-    Unlisted posts (quiet public in mastodon) are posts that opt out of search, including hashtag
-    searches on other instances. This is not recommended for art posts,
-    or anything you want to be discoverable!
-  </p>
-</section>
 <section *ngIf="false && uploadedMedias.length === 0" class="mt-3" id="pollControls">
   <button class="w-full" mat-button (mousedown)="quoteOpen = true" mat-flat-button>
     add poll
@@ -152,6 +141,17 @@
       </span>
       }
     </div>
+  </section>
+
+  <section id="privacy-messages">
+    <mat-card appearance="outlined" *ngIf="privacy === 10" class="mb-2 mt-1 mat-card-important">
+        <mat-card-content>Attention! ADMINS of both your instance, and the external instance can read
+        these DMs.</mat-card-content>
+    </mat-card>
+    <mat-card appearance="outlined" *ngIf="privacy === 3" class="mb-2 mt-1">
+        <mat-card-content>This post is set as unlisted. It opts out of search, hashtags
+          and other features. This is not recommended for anything you want discoverable.</mat-card-content>
+    </mat-card>
   </section>
 
   <button mat-flat-button class="w-full mt-2 flex-row" [disabled]="

--- a/packages/frontend/src/app/pages/profile/edit-profile/edit-profile.component.html
+++ b/packages/frontend/src/app/pages/profile/edit-profile/edit-profile.component.html
@@ -4,7 +4,7 @@
       <label for="avatar" class="block text-900 font-medium mb-2">Choose another avatar</label>
       <input formControlName="avatar" id="avatar" type="file" accept="image/jpeg,image/png,image/webp,image/gif"
         (change)="imgSelected($event)" class="w-full mb-3" />
-    </div>
+      </div>
 
     <mat-form-field class="w-full">
       <mat-label>Display name (can contain emoji codes)</mat-label>
@@ -20,75 +20,66 @@
         <button pButton type="button" class="ql-link" aria-label="Insert Link" title="Insert Link"></button>
       </div>
     </quill-editor>
+    <hr>
+    <span>Options</span>
+    <mat-form-field class="w-full">
+      <mat-label>Default post privacy</mat-label>
+      <mat-select [required]="true" formControlName="defaultPostEditorPrivacy">
+        @for(option of privacyOptions; track $index) {
+        <mat-option [value]="option.level">{{ option.name }}</mat-option>
+        }
+      </mat-select>
+    </mat-form-field>
+    <mat-form-field class="w-full">
+      <mat-label>Asks</mat-label>
+      <mat-select [required]="true" formControlName="asksLevel">
+        @for(option of askOptions; track $index) {
+        <mat-option [value]="option.level">{{ option.name }}</mat-option>
+        }
+      </mat-select>
+    </mat-form-field>
+    <div class="w-full">
+      <mat-checkbox formControlName="manuallyAcceptsFollows"></mat-checkbox>
+      <mat-label>Manualy accept follows</mat-label>
+    </div>
+    <div class="w-full">
+      <mat-checkbox formControlName="disableForceAltText"></mat-checkbox>
+      <mat-label>Allow uploading media without alt text (enable this only if you're
+        evil)</mat-label>
+    </div>
+    <div class="w-full">
+      <mat-checkbox formControlName="forceClassicLogo"></mat-checkbox>
+      <mat-label>Force classic logo</mat-label>
+    </div>
+    <div class="w-full">
+      <mat-checkbox formControlName="disableCW"></mat-checkbox>
+      <mat-label>Disable CW unless post contains muted words</mat-label>
+    </div>
+    <div class="w-full">
+      <mat-checkbox formControlName="federateWithThreads"></mat-checkbox>
+      <mat-label>Enable federation with Threads (meta/facebook)</mat-label>
+    </div>
+    <mat-card appearance="outlined" class="my-4">
+          <mat-card-content>Threads is a microblogging platform by Meta (formerly Facebook). We
+            understand not everyone will want to make their content available there.
+            By default meta will not see you, unless you enable this option.</mat-card-content>
+    </mat-card>
+    <section id="tags" class="mt-2 w-full flex-row">
+      <mat-form-field class="w-full">
+        <mat-label>Muted words separated by commas</mat-label>
+        <input formControlName="mutedWords" placeholder="Separated by commas" matNativeControl />
+      </mat-form-field>
+      <div *ngIf="editProfileForm.value.mutedWords.split(',').length > 0" class="taglist">
+        Muted phrases:
+        @for(tag of editProfileForm.value.mutedWords.split(','); track $index) {
+        <span *ngIf="tag && tag !== '' && tag.trim() !== ''" class="tag">
+          {{ tag.trim() }}
+        </span>
+        }
+      </div>
+    </section>
+    <hr>
     <mat-accordion>
-      <mat-expansion-panel hideToggle>
-        <mat-expansion-panel-header>
-          <mat-panel-title>
-            Options
-          </mat-panel-title>
-          <mat-panel-description>
-            Wafrn options like federating with threads, default post privacy...
-          </mat-panel-description>
-        </mat-expansion-panel-header>
-        <mat-form-field class="w-full">
-          <mat-label>Default post privacy</mat-label>
-          <mat-select [required]="true" formControlName="defaultPostEditorPrivacy">
-            @for(option of privacyOptions; track $index) {
-            <mat-option [value]="option.level">{{ option.name }}</mat-option>
-            }
-          </mat-select>
-        </mat-form-field>
-        <mat-form-field class="w-full">
-          <mat-label>Asks</mat-label>
-          <mat-select [required]="true" formControlName="asksLevel">
-            @for(option of askOptions; track $index) {
-            <mat-option [value]="option.level">{{ option.name }}</mat-option>
-            }
-          </mat-select>
-        </mat-form-field>
-        <div class="w-full">
-          <mat-checkbox formControlName="manuallyAcceptsFollows"></mat-checkbox>
-          <mat-label>Manualy accept follows</mat-label>
-        </div>
-        <div class="w-full">
-          <mat-checkbox formControlName="disableForceAltText"></mat-checkbox>
-          <mat-label>Allow uploading media without alt text (enable this only if you're
-            evil)</mat-label>
-        </div>
-        <div class="w-full">
-          <mat-checkbox formControlName="forceClassicLogo"></mat-checkbox>
-          <mat-label>Force classic logo</mat-label>
-        </div>
-        <div class="w-full">
-          <mat-checkbox formControlName="disableCW"></mat-checkbox>
-          <mat-label>Disable CW unless post contains muted words</mat-label>
-        </div>
-        <div class="w-full">
-          <mat-checkbox formControlName="federateWithThreads"></mat-checkbox>
-          <mat-label>Enable federation with Threads (meta/facebook)</mat-label>
-        </div>
-        <div class="flex align-items-center justify-content-between mb-6">
-          <p>Threads is a platform created by meta (formerly facebook). We understand
-            both the fact that you might want to federate with them, and also that you
-            may not. Hence why, unlike in other places, this kind of decisions are for
-            you to make. By default meta will not see you, unless you mark this option
-            in your profile.</p>
-        </div>
-        <section id="tags" class="mt-2 w-full flex-row">
-          <mat-form-field class="w-full">
-            <mat-label>Muted words separated by commas</mat-label>
-            <input formControlName="mutedWords" placeholder="Separated by commas" matNativeControl />
-          </mat-form-field>
-          <div *ngIf="editProfileForm.value.mutedWords.split(',').length > 0" class="taglist">
-            Muted phrases:
-            @for(tag of editProfileForm.value.mutedWords.split(','); track $index) {
-            <span *ngIf="tag && tag !== '' && tag.trim() !== ''" class="tag">
-              {{ tag.trim() }}
-            </span>
-            }
-          </div>
-        </section>
-      </mat-expansion-panel>
       <mat-expansion-panel hideToggle>
         <mat-expansion-panel-header>
           <mat-panel-title>

--- a/packages/frontend/src/styles.scss
+++ b/packages/frontend/src/styles.scss
@@ -361,7 +361,11 @@ table,
 mat-paginator,
 .ql-mention-list-container,
 .mat-mdc-menu-panel {
-  background-color: $cardcolor !important;
+  /* background-color: $cardcolor !important; */
+  --mdc-outlined-card-container-color: transparent;
+  --mdc-outlined-card-outline-color: #999999;
+  --mdc-elevated-card-container-color: #2a323d;
+  --mat-paginator-container-background-color: #2a323d;
 }
 
 
@@ -390,4 +394,12 @@ pre {
 
 .mat-mdc-dialog-inner-container > .mat-mdc-dialog-surface {
     padding: 20px;
+}
+
+/* NOTE: This is a custom class not provided by Angular. */
+/* The !important is here because angular later overrides the color. */
+/* This should be fine as it's only used sparingly. */
+.mat-card-important {
+  background-color: rgba(#f22f2f, 0.5) !important;
+  --mdc-outlined-card-outline-color:#ff5b5b !important;
 }


### PR DESCRIPTION
sorry I realised my branch name sounded like a minecraft update, anyways

This PR includes, but probably isn't limited to (I forgor):
- Changing the icons and title of various sidebar elements to better reflect their purpose.
  This can be seen with, for example, the "Edit my theme" option now having a paintbrush icon.

- Adding cards around various text in the UI to make them feel more "at home"
  seen in the new-edit dialogue, the settings

- Rewriting texts to be more conscise (threads fed, unlisted/DM options)

- Removing a `!important` style override for card colours This allows users to more easily change these variables for theming.

- Moving the "Wafrn options" out of a dropdown Makes the whole page feel less empty, but also makes it look better on narrow screens like mobile devices.

## Screenshots (where relevant):
![](https://github.com/user-attachments/assets/9ab4e813-bbb4-4d8c-a436-8ab7f8010e82)
![](https://github.com/user-attachments/assets/be1f740d-4989-4bcd-8973-c4acc60bd248)
![](https://github.com/user-attachments/assets/57448d5a-65f7-4db7-9ac9-1fc723e0c74a)
<img src="https://github.com/user-attachments/assets/3356c130-1f32-4755-97eb-870a93a157f0" width="450px">
