### PR TITLE
Fix long names breaking forum feed

### DIFF
--- a/packages/frontend/src/app/pages/forum/forum.component.html
+++ b/packages/frontend/src/app/pages/forum/forum.component.html
@@ -28,8 +28,10 @@
     @else {
     <mat-card class="p-3 pb-2 mb-2 lg:mx-4 scalein wafrn-container flex-shrink-0">
       <div class="flex">
-        <app-avatar-small class="mr-2" [user]="content.user"></app-avatar-small> {{content.user.url}} rewooted <a
-          class="ml-1" [routerLink]="'/fediverse/post/' + content.parentId"> this post</a>
+        <app-avatar-small class="mr-2" [user]="content.user"></app-avatar-small>
+        <div class="break-words">
+          {{content.user.url}} rewooted <a [routerLink]="'/fediverse/post/' + content.parentId">this post</a>
+        </div>
       </div>
     </mat-card>
     }

--- a/packages/frontend/src/app/pages/forum/forum.component.html
+++ b/packages/frontend/src/app/pages/forum/forum.component.html
@@ -29,7 +29,7 @@
     <mat-card class="p-3 pb-2 mb-2 lg:mx-4 scalein wafrn-container flex-shrink-0">
       <div class="flex">
         <app-avatar-small class="mr-2" [user]="content.user"></app-avatar-small>
-        <div class="break-words">
+        <div style="word-break: break-word">
           {{content.user.url}} rewooted <a [routerLink]="'/fediverse/post/' + content.parentId">this post</a>
         </div>
       </div>


### PR DESCRIPTION
Fixes #134 by splitting the text from the image for the flex. Also adds `break-words` to make super long usernames work correctly. The word break stuff should probably also be applied elsewhere for mobile support.

I can't set up the frontend 'cause bugs so here's the simulated version:

## Before

![image](https://github.com/user-attachments/assets/9a3eb75a-c1cf-4683-ab4a-9d5e021d0b28)

## After

![image](https://github.com/user-attachments/assets/d1bfc362-d56e-4e53-a90b-830e7aa5961c)

