### PR TITLE
Fixes the blog header image styles to scale up tiny images

### DIFF
--- a/packages/frontend/src/app/components/blog-header/blog-header.component.html
+++ b/packages/frontend/src/app/components/blog-header/blog-header.component.html
@@ -1,7 +1,7 @@
 <mat-card class="wafrn-container p-3 lg:mx-4 mb-6 over overflow-hidden">
   <div class="flex align-content-end justify-content-center header-image" [style.background]="'url('+ headerUrl + ')'">
-    <img [src]="avatarUrl" alt="user avatar"
-      class="border-round-md mt-6 mb-4 max-w-full h-[15vh]" />
+    <img style="height: 15vh" [src]="avatarUrl" alt="user avatar"
+      class="border-round-md mt-6 mb-4 max-w-full" />
   </div>
 
   <div class="flex justify-content-center flex-wrap">

--- a/packages/frontend/src/app/components/blog-header/blog-header.component.html
+++ b/packages/frontend/src/app/components/blog-header/blog-header.component.html
@@ -1,7 +1,7 @@
 <mat-card class="wafrn-container p-3 lg:mx-4 mb-6 over overflow-hidden">
   <div class="flex align-content-end justify-content-center header-image" [style.background]="'url('+ headerUrl + ')'">
-    <img style="max-width: 100%; max-height: 15vh" [src]="avatarUrl" alt="user avatar"
-      class="border-round-md mt-6 mb-4" />
+    <img [src]="avatarUrl" alt="user avatar"
+      class="border-round-md mt-6 mb-4 max-w-full h-[15vh]" />
   </div>
 
   <div class="flex justify-content-center flex-wrap">


### PR DESCRIPTION
> [!WARNING]
> **THE CHANGE FROM `max-height` TO JUST `height` MAY NOT BE DESIRABLE**
> 
> If you think it would negatively impact the aesthetic, please comment and I'll change it to using tailwind styles but with max-height

Changes the inlined styles to be tailwind styles and makes the max-height just height to scale up smaller profile pictures, similar to how the `.avatar` sets them to a pixel value.

## Before

![image](https://github.com/user-attachments/assets/390d2a00-26dd-484a-ae6a-dfa916572c92)

## After (Simulated)

![image](https://github.com/user-attachments/assets/28426d12-0a93-4c28-9ebb-39468961f2e4)
