### PR TITLE
Add overflow-wrap on the entire site

### DIFF
--- a/packages/frontend/src/styles.scss
+++ b/packages/frontend/src/styles.scss
@@ -42,6 +42,7 @@ html {
   @include mat.all-component-themes($dark-theme);
   //font-family: $font-family;
   //background-color: var(--bgcolor)
+  overflow-wrap: break-word;
 }
 
 @include mat.color-variants-backwards-compatibility($dark-theme);


### PR DESCRIPTION
A better default for wrapping everything!

Some examples:

User descriptions

![image](https://github.com/user-attachments/assets/11870807-307e-46b8-87c1-6b80ec6a5636)

Image captions

![image](https://github.com/user-attachments/assets/b23a4147-e7c5-4233-9691-6103b016b400)

User names

![image](https://github.com/user-attachments/assets/9fd7f947-00f0-43bd-a5cc-dd0722930762)

Some other stuff has to be specifically targeted with `overflow-wrap` but that's more for specific things inside flex elements and stuffs.
