### PR TITLE
Fix sidebar overscroll behavior

### DIFF
--- a/packages/frontend/src/styles.scss
+++ b/packages/frontend/src/styles.scss
@@ -444,6 +444,10 @@ mat-paginator,
   max-height: unset !important;
 }
 
+.mat-drawer-inner-container {
+  overscroll-behavior-y: contain;
+}
+
 pre {
   overflow-x: scroll
 }


### PR DESCRIPTION
Changes the sidebar to not scroll past the sidebar container for mobile devices.

Without this, continuing to scroll on the sidebar after it had reached the end would starts scrolling the main screen. This pull request fixes that so you don't scroll.

https://github.com/user-attachments/assets/8f952984-6d82-4045-9db2-23d81cb13b12

