### PR TITLE
Fix the wafrn logo popping in and messing up the screen

### DIFF
--- a/packages/frontend/src/app/components/navigation-menu/navigation-menu.component.html
+++ b/packages/frontend/src/app/components/navigation-menu/navigation-menu.component.html
@@ -2,7 +2,13 @@
   <mat-drawer style="position: fixed; border-radius: 0" class="side-menu" [mode]="mobile ? 'over' : 'side'"
     [opened]="menuVisible || !mobile" (closed)="hideMenu()">
     <a [href]="'/'" class="block" (mousedown)="hideMenu()">
-      <img [src]="logo" class="block mx-auto my-3" alt="instance logo" style="max-width: 200px; max-height: 72px" />
+      <img
+        [src]="logo"
+        class="block mx-auto my-3"
+        alt="instance logo"
+        width="200"
+        style="aspect-ratio: 3 / 1; object-fit: contain;"
+      />
     </a>
     <hr class="mx-3" />
     <mat-nav-list>


### PR DESCRIPTION
The logo didn't set its height or width explicitly so it would pop in and cause a slight layout shift.

This sets the width on the image itself and uses `aspect-ratio` and `object-fit: contain` to keep the image to that size without stretching it.

> [!NOTE]  
> The aspect ratio used was `3 / 1` which is pretty close but not exactly the intrinsic ratio of 821∶257. As such, it was necessary to use `object-fit: contain`.

## Before

Causes a minor layout shift on reload, causes major layout shift on first load.

https://github.com/user-attachments/assets/4535f3a5-808f-40d2-8f72-e229ccfaacfe

## After

No layout shifts on reload, no layout shift on first load.

https://github.com/user-attachments/assets/d7b89093-e1fe-4213-b2ff-1fb46e401df0



