### PR TITLE
Improve global styles and move to mat-sys based variables

### DIFF
--- a/packages/frontend/src/app/components/blog-header/blog-header.component.html
+++ b/packages/frontend/src/app/components/blog-header/blog-header.component.html
@@ -1,17 +1,18 @@
-<mat-card class="wafrn-container p-3 lg:mx-4 mb-6 over overflow-hidden">
-  <div class="flex align-content-end justify-content-center header-image" [style.background]="'url('+ headerUrl + ')'">
+<mat-card class="wafrn-container p-3 lg:mx-4 overflow-hidden mb-6 blog-header">
+  <div class="flex align-content-end justify-content-center header-image mb-2" [style.background-image]="'url('+ headerUrl + ')'">
     <img style="max-width: 100%; max-height: 15vh" [src]="avatarUrl" alt="user avatar"
       class="border-round-md mt-6 mb-4" />
   </div>
 
   <div class="flex justify-content-center flex-wrap">
-    <div [innerHtml]="blogDetails.name" class="text-xl font-medium line-height-3"></div>
+    <p [innerHtml]="blogDetails.name" class="m-0 text-xl font-medium line-height-3"></p>
   </div>
-  <div class="flex justify-content-center flex-wrap mb-2">
-    <div [innerText]="blogDetails.url" class="line-height-3"></div>
+  <div class="flex justify-content-center flex-wrap">
+    <p [innerText]="blogDetails.url" class="m-0 text-sm line-height-3 blog-url"></p>
   </div>
+  <hr class="w-full my-3">
   @if (userLoggedIn && !isMe) {
-  <div *ngIf="userLoggedIn" class="flex gap-0 flex-nowrap w-min mx-auto">
+  <div *ngIf="userLoggedIn" class="flex gap-0 flex-nowrap mx-auto">
     <button mat-stroked-button [color]="
           postService.followedUserIds.indexOf(blogDetails.id) === -1 ? 'primary' : 'warn'
         " *ngIf="!postService.notYetAcceptedFollowedUsersIds.includes(blogDetails.id)" class="split-button-left"
@@ -63,43 +64,57 @@
     } }
   </mat-menu>
   }
-  <div class="flex justify-content-center flex-wrap mt-3 mb-2">
+  <div class="mt-3 mb-2">
     <div style="word-wrap: anywhere" [innerHtml]="blogDetails.description"></div>
   </div>
-  <table *ngIf="fediAttachment" class="w-full overflow-hidden">
-    <tr *ngFor="let fediAt of fediAttachment">
-      <th [innerHTML]="fediAt.name"></th>
-      <th [innerHTML]="fediAt.value"></th>
-    </tr>
+  @if (fediAttachment.length !== 0) {
+  <hr class="w-full my-3">
+  <div class="w-full overflow-hidden flex flex-column gap-2">
+    <p>Fediverse Attachments</p>
+    <dl *ngFor="let fediAt of fediAttachment" class="flex m-0">
+      <dt [innerHTML]="fediAt.name" class="w-3"></dt>
+      <dd [innerHTML]="fediAt.value" class="w-8 ml-2"></dd>
+    </dl>
+  </div>
+  }
+  @if (allowAsk) {
 
-  </table>
   <div class="flex justify-content-center flex-wrap">
-    <button *ngIf="allowAsk" mat-stroked-button [innerHTML]="'Ask ' +blogDetails.name + ' something'"
+    <button mat-stroked-button [innerHTML]="'Ask ' +blogDetails.name + ' something'"
       (mousedown)="openAskDialog()"></button>
-
   </div>
-  <div *ngIf="!blogDetails.url.startsWith('@') || (blogDetails.followers && blogDetails.followed)"
-    class="follow-counts">
-    <div [routerLink]="['/blog', blogDetails.url ,'following']">
-      <p>Following</p>
-      <p class="big text-center">{{ blogDetails.followed }}</p>
-    </div>
-    <div [routerLink]="['/blog', blogDetails.url ,'followers']">
-      <p>Followed</p>
-      <p class="big text-center">{{ blogDetails.followers }}</p>
-    </div>
+  }
+  @if (!blogDetails.url.startsWith('@') || (blogDetails.followers && blogDetails.followed)) {
+  <hr class="w-full my-3">
+  <div class="flex justify-content-evenly follow-counts">
+    <a [routerLink]="['/blog', blogDetails.url ,'following']" class="flex flex-column justify-content-center">
+      <b class="m-0 text-lg text-center">{{ blogDetails.followed }}</b>
+      <p class="m-0 text-xs">Following</p>
+    </a>
+    <a [routerLink]="['/blog', blogDetails.url ,'followers']" class="flex flex-column justify-content-center">
+      <b class="m-0 text-lg text-center">{{ blogDetails.followers }}</b>
+      <p class="m-0 text-xs">Followers</p>
+    </a>
   </div>
-  <div class="mt-6 text-sm" *ngIf="blogDetails.url.startsWith('@')">
-    <strong>Attention!</strong>
-    This is an external user, and the profile might not be complete.
-    <br />
-    To check this user's complete profile in their instance,
-    <a [href]="blogDetails.url.split('@').length == 3 ? blogDetails.remoteId : ('https://bsky.app/profile/' + blogDetails.url.split('@')[1])"
-      target="_blank"> click here</a>.
+  }
+  <div *ngIf="allowRemoteAsk" class="justify-content-center">
+    <p class="m-0">
+      You can send this user a non-anonymous ask from your fedi instance with
+      the following structure: " !ask &#64;{{ blogDetails.url }} YOUR QUESTION
+      HERE". The medias and emojis you attach will be ignored, and you can only
+      send one mention on the post. If it goes wrong, the user will receive it
+      as a regular DM. Also, the content of the DM will be published as the AP
+      object to verify the ask as genuine
+    </p>
   </div>
-  <div *ngIf="allowRemoteAsk" class="justify-content-center">You can send this user a non-anonymous ask from your fedi
-    instance with the following
-    structure: " !ask &#64;{{blogDetails.url}} YOUR QUESTION HERE". The medias and emojis you attach will be ignored,
-    and you can only send one mention on the post. If it goes wrong, the user will receive it as a regular DM. Also, the
-    content of the DM will be published as the AP object to verify the ask as genuine</div>
 </mat-card>
+<app-info-card
+  [type]="infoAlert"
+  class="block p-4 pt-3 pb-6 wafrn-container notification"
+  *ngIf="blogDetails.url.startsWith('@')"
+  >As this user is from a remote instance, the shown information may be
+  incomplete.
+  <a [href]="blogDetails.url.split('@').length == 3 ? blogDetails.remoteId : ('https://bsky.app/profile/' + blogDetails.url.split('@')[1])" target="_blank"
+    >View on remote instance</a
+  >
+</app-info-card>

--- a/packages/frontend/src/app/components/blog-header/blog-header.component.html
+++ b/packages/frontend/src/app/components/blog-header/blog-header.component.html
@@ -8,7 +8,7 @@
     <div [innerHtml]="blogDetails.name" class="text-xl font-medium line-height-3"></div>
   </div>
   <div class="flex justify-content-center flex-wrap mb-2">
-    <div [innerText]="blogDetails.url" class="text-600 line-height-3"></div>
+    <div [innerText]="blogDetails.url" class="line-height-3"></div>
   </div>
   @if (userLoggedIn && !isMe) {
   <div *ngIf="userLoggedIn" class="flex gap-0 flex-nowrap w-min mx-auto">
@@ -89,7 +89,7 @@
       <p class="big text-center">{{ blogDetails.followers }}</p>
     </div>
   </div>
-  <div class="mt-6 text-600 text-sm" *ngIf="blogDetails.url.startsWith('@')">
+  <div class="mt-6 text-sm" *ngIf="blogDetails.url.startsWith('@')">
     <strong>Attention!</strong>
     This is an external user, and the profile might not be complete.
     <br />

--- a/packages/frontend/src/app/components/blog-header/blog-header.component.scss
+++ b/packages/frontend/src/app/components/blog-header/blog-header.component.scss
@@ -1,38 +1,47 @@
+.blog-header {
+  background-color: var(--mat-sys-surface-container-high);
+}
+
+.blog-url {
+  color: var(--mat-sys-outline);
+}
+
 .split-button-left {
+  padding-right: 16px;
   border-top-right-radius: 0;
   border-bottom-right-radius: 0;
   min-width: 0;
 }
 
 .split-button-right {
-  width: 30px !important;
-  min-width: unset !important;
-  padding: 0 2px;
+  padding-left: 8px;
+  padding-right: 10px;
   border-top-left-radius: 0;
   border-bottom-left-radius: 0;
-  border-left: 1px solid #ffffff44;
+  border-left: 0;
 }
 
-.follow-counts {
-  margin: 12px auto;
-  display: flex;
-  gap: 32px;
-}
+.follow-counts > a {
+  text-decoration: none;
 
-.follow-counts p {
-  margin: 0;
-}
-
-.follow-counts .big {
-  margin-top: 8px;
-  font-size: 24px;
+  &:hover {
+    text-decoration: underline;
+  }
 }
 
 .header-image {
+  background-color: var(--mat-sys-surface-container-highest);
+  box-shadow: 0 0 5px -1px rgba(0, 0, 0, 0.1) inset,
+    0 0 10px 0 rgba(0, 0, 0, 0.07) inset, 0 0 18px 0 rgba(0, 0, 0, 0.06) inset;
+  border-radius: var(--mat-sys-corner-small) var(--mat-sys-corner-small) 0 0;
   background-position: center center;
   background-repeat: no-repeat;
   -webkit-background-size: cover;
   -moz-background-size: cover;
   -o-background-size: cover;
   background-size: cover;
+}
+
+mat-card:has(+ app-info-card) {
+  margin-bottom: 0 !important;
 }

--- a/packages/frontend/src/app/components/blog-header/blog-header.component.ts
+++ b/packages/frontend/src/app/components/blog-header/blog-header.component.ts
@@ -6,7 +6,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { MatMenuModule } from '@angular/material/menu';
 import { RouterModule } from '@angular/router';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
-import { faChevronDown, faServer, faUser, faUserSlash, faVolumeMute, faVolumeUp } from '@fortawesome/free-solid-svg-icons';
+import { faChevronDown, faExclamationTriangle, faServer, faUser, faUserSlash, faVolumeMute, faVolumeUp } from '@fortawesome/free-solid-svg-icons';
 import { BlogDetails } from 'src/app/interfaces/blogDetails';
 import { BlocksService } from 'src/app/services/blocks.service';
 import { LoginService } from 'src/app/services/login.service';
@@ -15,6 +15,7 @@ import { PostsService } from 'src/app/services/posts.service';
 
 import { AskDialogContentComponent } from '../ask-dialog-content/ask-dialog-content.component';
 import { EnvironmentService } from 'src/app/services/environment.service';
+import { InfoCardComponent } from '../info-card/info-card.component';
 
 @Component({
     selector: 'app-blog-header',
@@ -25,6 +26,7 @@ import { EnvironmentService } from 'src/app/services/environment.service';
         MatMenuModule,
         MatButtonModule,
         RouterModule,
+        InfoCardComponent
     ],
     templateUrl: './blog-header.component.html',
     styleUrl: './blog-header.component.scss'
@@ -44,6 +46,7 @@ export class BlogHeaderComponent implements OnChanges, OnDestroy {
   unblockServerIcon = faServer;
   allowAsk = false;
   allowRemoteAsk = false;
+  infoAlert = faExclamationTriangle;
 
 
 

--- a/packages/frontend/src/app/components/file-upload/file-upload.component.html
+++ b/packages/frontend/src/app/components/file-upload/file-upload.component.html
@@ -18,5 +18,5 @@
 </div>
 
 <div *ngIf="uploadStatus === UploadStatus.Uploading" class="flex mt-3 align-items-center justify-content-center w-full">
-  <mat-spinner color="accent" diameter="25"></mat-spinner>
+  <mat-spinner color="accent" diameter="24"></mat-spinner>
 </div>

--- a/packages/frontend/src/app/components/info-card/info-card.component.html
+++ b/packages/frontend/src/app/components/info-card/info-card.component.html
@@ -1,0 +1,5 @@
+<div class="info-card">
+  <p class="m-0 text-sm">
+    <fa-icon [icon]="type()" size="sm" /><ng-content></ng-content>
+  </p>
+</div>

--- a/packages/frontend/src/app/components/info-card/info-card.component.scss
+++ b/packages/frontend/src/app/components/info-card/info-card.component.scss
@@ -1,0 +1,13 @@
+.info-card {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  background-color: var(--info-card-warning-background);
+  color: var(--mat-sys-on-surface-container-low);
+  border-radius: var(--mat-sys-corner-small);
+  padding: 0.5rem 1rem;
+
+  & fa-icon {
+    margin-right: 1ch;
+  }
+}

--- a/packages/frontend/src/app/components/info-card/info-card.component.ts
+++ b/packages/frontend/src/app/components/info-card/info-card.component.ts
@@ -1,0 +1,13 @@
+import { Component, computed, input } from '@angular/core';
+import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
+import { IconDefinition } from '@fortawesome/free-solid-svg-icons';
+
+@Component({
+  selector: 'app-info-card',
+  imports: [FontAwesomeModule],
+  templateUrl: './info-card.component.html',
+  styleUrl: './info-card.component.scss',
+})
+export class InfoCardComponent {
+  type = input.required<IconDefinition>();
+}

--- a/packages/frontend/src/app/components/loader/loader.component.html
+++ b/packages/frontend/src/app/components/loader/loader.component.html
@@ -1,3 +1,4 @@
-<mat-card class="p-3 mb-6 lg:mx-4 scalein wafrn-container align-items-center">
-  <mat-spinner></mat-spinner>
+<mat-card class="p-4 m-2 mb-6 lg:mx-4 wafrn-container align-items-center">
+  <mat-spinner color="accent" diameter="32"></mat-spinner>
+  <p class="mt-2 mb-0 text-lg">Loading <ng-content></ng-content></p>
 </mat-card>

--- a/packages/frontend/src/app/components/navigation-menu/navigation-menu.component.html
+++ b/packages/frontend/src/app/components/navigation-menu/navigation-menu.component.html
@@ -1,10 +1,10 @@
 <mat-drawer-container>
-  <mat-drawer style="position: fixed; border-radius: 0" class="side-menu" [mode]="mobile ? 'over' : 'side'"
+  <mat-drawer style="position: fixed; border-radius: 0" class="p-2 side-menu" [mode]="mobile ? 'over' : 'side'"
     [opened]="menuVisible || !mobile" (closed)="hideMenu()">
     <a [href]="'/'" class="block" (mousedown)="hideMenu()">
       <img [src]="logo" class="block mx-auto my-3" alt="instance logo" style="max-width: 200px; max-height: 72px" />
     </a>
-    <hr class="mx-3" />
+    <hr/>
     <mat-nav-list>
       @for (link of menuItems; track $index) { @if (link.divider) {
       <hr style="margin: 16px 0" />

--- a/packages/frontend/src/app/components/navigation-menu/navigation-menu.component.html
+++ b/packages/frontend/src/app/components/navigation-menu/navigation-menu.component.html
@@ -15,7 +15,7 @@
   </mat-drawer>
   <mat-drawer-content>
     <button style="position: fixed; z-index: 500; top: 1em; left: 0.5em" mat-flat-button color="primary"
-      *ngIf="!menuVisible" [hidden]="!mobile" type="button" class="show-sidebar-menu-button"
+      [hidden]="!mobile" type="button" class="show-sidebar-menu-button"
       (mousedown)="showMenu()"
       [matBadge]="notifications + adminNotifications + usersAwaitingAproval + followsAwaitingAproval + awaitingAsks"
       [matBadgeHidden]="

--- a/packages/frontend/src/app/components/navigation-menu/navigation-menu.component.scss
+++ b/packages/frontend/src/app/components/navigation-menu/navigation-menu.component.scss
@@ -2,6 +2,7 @@
 .side-menu {
   height: 100vh;
   display: block;
+  box-shadow: var(--mat-sys-level2);
 }
 
 .mat-drawer-content {

--- a/packages/frontend/src/app/components/navigation-menu/navigation-menu.component.scss
+++ b/packages/frontend/src/app/components/navigation-menu/navigation-menu.component.scss
@@ -2,6 +2,7 @@
 .side-menu {
   height: 100vh;
   display: block;
+  background: var(--mat-sys-surface-container-low);
   box-shadow: var(--mat-sys-level2);
 }
 

--- a/packages/frontend/src/app/components/new-editor/new-editor.component.html
+++ b/packages/frontend/src/app/components/new-editor/new-editor.component.html
@@ -111,7 +111,7 @@
 
 <section id="quote">
   <div *ngIf="!data?.quote">
-    <mat-spinner *ngIf="quoteLoading" class="my-4" color="accent" diameter="42"></mat-spinner>
+    <mat-spinner *ngIf="quoteLoading" class="my-4" color="accent" diameter="24"></mat-spinner>
 
   </div>
   <div *ngIf="data && data.quote" class="my-4">

--- a/packages/frontend/src/app/components/post-fragment/post-fragment.component.html
+++ b/packages/frontend/src/app/components/post-fragment/post-fragment.component.html
@@ -78,7 +78,7 @@
       } @else {
       <button [ngClass]="{
         blurry: (fragment.content_warning || fragment.muted_words_cw) && showCw
-      }" [matTooltip]="emoji.tooltip " mat-stroked-button>
+      }" [matTooltip]="emoji.tooltip " mat-raised-button>
         @if (emoji.img) {
         <img class="post-emoji" [src]="emoji.img" [alt]="emoji.content" />
         } @else {

--- a/packages/frontend/src/app/components/post-fragment/post-fragment.component.html
+++ b/packages/frontend/src/app/components/post-fragment/post-fragment.component.html
@@ -21,9 +21,9 @@
   </div>
   <div
     [ngClass]="{ 'post-danger': (fragment.content_warning || fragment.muted_words_cw) && showCw, 'mt-4': (fragment.content_warning || fragment.muted_words_cw)}">
-    <div *ngFor="let block of wafrnFormattedContent" class="fragment-content wafrn-text-default overflow-hidden"
+    <div *ngFor="let block of wafrnFormattedContent" class="fragment-content overflow-hidden"
       [ngClass]="{ blurry: (fragment.content_warning || fragment.muted_words_cw) && showCw }">
-      <div [injectHTML]="block"></div>
+      <div [injectHTML]="block" class="post-text"></div>
       <app-wafrn-media [mediaOrString]="block"></app-wafrn-media>
     </div>
 
@@ -35,7 +35,7 @@
       [ngClass]="{ blurry: (fragment.content_warning || fragment.muted_words_cw) && showCw }">
       <app-wafrn-media *ngIf="!seenMedia.includes(i)" [data]="media"></app-wafrn-media>
     </div>
-    <div id="fragment-tags" class="flex flex-wrap gap-2 mt-4" *ngIf="fragment.tags && fragment.tags.length"
+    <div class="flex flex-wrap gap-2 mt-3 mb-2 tag-list" *ngIf="fragment.tags && fragment.tags.length"
       [ngClass]="{ blurry: (fragment.content_warning || fragment.muted_words_cw) && showCw }">
       @for(tag of fragment.tags; track $index) {
       <a class="tag" [routerLink]="'/dashboard/search/' + tag.tagName">
@@ -54,7 +54,7 @@
       </div>
     </div>
     }
-    <section class="mt-2" id="emoji-reactions">
+    <section class="mt-3" id="emoji-reactions">
       @for (emoji of emojiCollection; track $index) {
 
       @if (avaiableEmojiNames.includes(emoji.name) || !emoji.img) {

--- a/packages/frontend/src/app/components/post-fragment/post-fragment.component.html
+++ b/packages/frontend/src/app/components/post-fragment/post-fragment.component.html
@@ -78,7 +78,7 @@
       } @else {
       <button [ngClass]="{
         blurry: (fragment.content_warning || fragment.muted_words_cw) && showCw
-      }" class="p-3" [matTooltip]="emoji.tooltip " mat-stroked-button>
+      }" [matTooltip]="emoji.tooltip " mat-stroked-button>
         @if (emoji.img) {
         <img class="post-emoji" [src]="emoji.img" [alt]="emoji.content" />
         } @else {

--- a/packages/frontend/src/app/components/post-fragment/post-fragment.component.scss
+++ b/packages/frontend/src/app/components/post-fragment/post-fragment.component.scss
@@ -8,15 +8,8 @@
 }
 
 .reacted {
-  background-color: rgba(#D6BAFF, 0.25);
-  color: white;
-}
-
-@media (prefers-color-scheme: light) {
-  .reacted {
-    background-color: rgba(#D6BAFF, 0.5);
-    color: black;
-  }
+  background-color: var(--mat-sys-primary);
+  color: var(--mat-sys-on-primary);
 }
 
 #emoji-reactions > button {

--- a/packages/frontend/src/app/components/post-fragment/post-fragment.component.scss
+++ b/packages/frontend/src/app/components/post-fragment/post-fragment.component.scss
@@ -20,8 +20,8 @@
 }
 
 #emoji-reactions > button {
-    margin-right: 6px;
-    margin-bottom: 4px;
-    /* what professional engineering right here */
-    vertical-align: -5.1%;
+  margin-right: 6px;
+  margin-bottom: 4px;
+  /* what professional engineering right here */
+  vertical-align: -5.1%;
 }

--- a/packages/frontend/src/app/components/post/post-header/post-header.component.html
+++ b/packages/frontend/src/app/components/post/post-header/post-header.component.html
@@ -16,7 +16,7 @@
     <app-post-actions *ngIf="!simplified" [content]="fragment"></app-post-actions>
   </div>
   <div *ngIf="!simplified" class="date-line mb-1 flex gap-2 align-items-center">
-    <span class="text-xs text-600">
+    <span class="text-xs">
       {{ fragment.createdAt | date : "short" }}
       <fa-icon [icon]="
               fragment.privacy === 0
@@ -32,7 +32,7 @@
     </span>
     <span *ngIf="
             fragment.updatedAt.getTime() - fragment.createdAt.getTime() > 60000
-          " class="text-xs text-600">
+          " class="text-xs">
       <fa-icon [matTooltip]="fragment.updatedAt.toLocaleString()" [icon]="editedIcon"></fa-icon>
     </span>
     <button mat-stroked-button color="accent" *ngIf="

--- a/packages/frontend/src/app/components/post/post.component.html
+++ b/packages/frontend/src/app/components/post/post.component.html
@@ -1,4 +1,4 @@
-<mat-card [id]="'post-element-' + finalPost.id" class="p-3 m-2 mb-6 lg:mx-4 scalein wafrn-container">
+<mat-card [id]="'post-element-' + finalPost.id" class="p-3 mx-2 mb-6 lg:mx-4 scalein wafrn-container">
   <div [ngClass]="{
       'shortened-post': veryLongPost || !showFull
     }">

--- a/packages/frontend/src/app/components/single-notification/single-notification.component.html
+++ b/packages/frontend/src/app/components/single-notification/single-notification.component.html
@@ -34,6 +34,5 @@
     <div class="cursor-pointer" [routerLink]="notification.url">
       <app-post-fragment [fragment]="notification.fragment"></app-post-fragment>
     </div>
-    <hr class="w-full dotted">
   </div>
 </mat-card>

--- a/packages/frontend/src/app/components/single-notification/single-notification.component.scss
+++ b/packages/frontend/src/app/components/single-notification/single-notification.component.scss
@@ -38,8 +38,3 @@
   bottom: 0;
   left: 0;
 }
-
-.dotted {
-  border: 1px dashed;
-  background-color: transparent;
-}

--- a/packages/frontend/src/app/pages/activate-account/activate-account.component.html
+++ b/packages/frontend/src/app/pages/activate-account/activate-account.component.html
@@ -2,8 +2,8 @@
   <div class="col-12 wafrn-post">
       <div class="text-center mb-5">
         <img loading="lazy" [src]="logo" alt="Image" height="50" class="mb-3">
-        <div class="text-900 text-3xl font-medium mb-3">Click on the button to activate your account</div>
-        <span class="text-600 font-medium line-height-3">And just log in after that!</span>
+        <div class="text-3xl font-medium mb-3">Click on the button to activate your account</div>
+        <span class="font-medium line-height-3">And just log in after that!</span>
         <br>
         <button (mousedown)="activateAccount()" >Activate</button>
 

--- a/packages/frontend/src/app/pages/admin/pending-users/pending-users.component.html
+++ b/packages/frontend/src/app/pages/admin/pending-users/pending-users.component.html
@@ -13,10 +13,10 @@
   </div>
   <div class="flex justify-content-center flex-wrap"></div>
   <div class="flex justify-content-center flex-wrap mb-2">
-    <div [innerText]="user.url" class="text-600 line-height-3"></div>
+    <div [innerText]="user.url" class="line-height-3"></div>
   </div>
   <div class="flex justify-content-center flex-wrap mb-2">
-    <div [innerText]="user.email" class="text-600 line-height-3"></div>
+    <div [innerText]="user.email" class="line-height-3"></div>
   </div>
   <div class="flex justify-content-center flex-wrap mt-3 mb-2">
     <div style="word-wrap: anywhere" [innerHtml]="user.description"></div>

--- a/packages/frontend/src/app/pages/ask-list/ask-list.component.html
+++ b/packages/frontend/src/app/pages/ask-list/ask-list.component.html
@@ -11,6 +11,11 @@
 }
 @if (!loading && asks.length === 0) {
 <footer class="m-2 mb-6 lg:mx-4 wafrn-container">
-  <p class="m-0 text-lg">No more asks found</p>
+  <p class="mb-4 text-lg">No more asks found</p>
+  <marquee scrollamount="12" class="m-0 text-lg">Nobody asked...</marquee>
+  <marquee scrollamount="11" class="m-0 text-lg">Nobody asked...</marquee>
+  <marquee scrollamount="10" class="m-0 text-lg">Nobody asked...</marquee>
+  <marquee scrollamount="9" class="m-0 text-lg">Nobody asked...</marquee>
+  <marquee scrollamount="8" class="m-0 text-lg">Nobody asked...</marquee>
 </footer>
 }

--- a/packages/frontend/src/app/pages/ask-list/ask-list.component.html
+++ b/packages/frontend/src/app/pages/ask-list/ask-list.component.html
@@ -1,13 +1,16 @@
-@if(loading){
-loading
-} @else {
-<h2 class="p-3 m-2 mb-6 lg:mx-4">Unanswered asks</h2>
+<div class="wafrn-container mx-1 md:mx-4">
+  <h3 class="m-0 text-2xl">Unanswered asks</h3>
+</div>
+<app-loader *ngIf="loading">posts</app-loader>
 @for(ask of asks; track $index) {
 <mat-card class="p-3 m-2 mb-6 lg:mx-4 scalein wafrn-container">
     <app-single-ask [ask]="ask"></app-single-ask>
     <button (mousedown)="replyAsk(ask)" mat-flat-button class="w-full mt-2">Answer</button>
     <button (click)="ignoreAsk(ask)" mat-stroked-button class="w-full mt-2">Ignore</button>
-
 </mat-card>
 }
+@if (!loading && asks.length === 0) {
+<footer class="m-2 mb-6 lg:mx-4 wafrn-container">
+  <p class="m-0 text-lg">No more asks found</p>
+</footer>
 }

--- a/packages/frontend/src/app/pages/ask-list/ask-list.component.ts
+++ b/packages/frontend/src/app/pages/ask-list/ask-list.component.ts
@@ -7,6 +7,7 @@ import { Ask } from 'src/app/interfaces/ask';
 import { BlogService } from 'src/app/services/blog.service';
 import { DashboardService } from 'src/app/services/dashboard.service';
 import { EditorService } from 'src/app/services/editor.service';
+import { LoaderComponent } from 'src/app/components/loader/loader.component';
 
 @Component({
     selector: 'app-ask-list',
@@ -14,7 +15,8 @@ import { EditorService } from 'src/app/services/editor.service';
         CommonModule,
         SingleAskComponent,
         MatButtonModule,
-        MatCardModule
+        MatCardModule,
+        LoaderComponent
     ],
     templateUrl: './ask-list.component.html',
     styleUrl: './ask-list.component.scss'

--- a/packages/frontend/src/app/pages/dashboard/dashboard.component.html
+++ b/packages/frontend/src/app/pages/dashboard/dashboard.component.html
@@ -1,18 +1,16 @@
-<div class="wafrn-container mx-1 md:mx-4 flex align-items-center">
-  <h3 class="flex-grow-1 m-0 text-2xl ">{{ title }}</h3>
-  <button (mousedown)="reloadPosts()" mat-flat-button color="default" aria-label="Refresh"
-    class="refresh-button" style="position: fixed; z-index: 500; top: 1em; right: 0.5em">
-    <fa-icon [icon]="reloadIcon" />
-  </button>
+<div *ngIf="title" class="wafrn-container mx-1 md:mx-4 flex align-items-center">
+  <h3 class="flex-grow-1 m-0 text-2xl">{{ title }}</h3>
 </div>
-<div *ngFor="let post of posts; let indexOfelement = index">
+<app-loader *ngIf="loadingPosts">posts</app-loader>
+@for (post of posts; track $index) {
   <app-post [post]="post"></app-post>
-</div>
+}
 <footer class="p-4 flex gap-3 align-items-center">
-  <mat-spinner *ngIf="!noMorePosts" diameter="42"></mat-spinner>
-  <p [hidden]="loadingPosts || noMorePosts" id="if-you-see-this-load-more-posts" class="m-0 text-lg text-600 ">
-    Loading more...
-  </p>
-  <p *ngIf="loadingPosts" class="m-0 text-lg text-600">Loading more posts</p>
-  <p *ngIf="noMorePosts" class="m-0 text-lg text-600">No more posts found</p>
+  <div [hidden]="loadingPosts || noMorePosts" id="if-you-see-this-load-more-posts" class="m-0 text-lg"></div>
+  <p *ngIf="noMorePosts" class="m-0 text-lg">No more posts found</p>
 </footer>
+
+<button (mousedown)="reloadPosts()" mat-flat-button color="default" aria-label="Refresh"
+  class="refresh-button" style="position: fixed; z-index: 500; top: 1em; right: 0.5em">
+  <fa-icon [icon]="reloadIcon" />
+</button>

--- a/packages/frontend/src/app/pages/dashboard/dashboard.component.ts
+++ b/packages/frontend/src/app/pages/dashboard/dashboard.component.ts
@@ -9,6 +9,7 @@ import { ThemeService } from 'src/app/services/theme.service';
 import { MessageService } from 'src/app/services/message.service';
 import { faArrowsRotate } from '@fortawesome/free-solid-svg-icons';
 import { Subscription } from 'rxjs';
+import { LoaderComponent } from 'src/app/components/loader/loader.component';
 
 @Component({
     selector: 'app-dashboard',

--- a/packages/frontend/src/app/pages/dashboard/dashboard.module.ts
+++ b/packages/frontend/src/app/pages/dashboard/dashboard.module.ts
@@ -7,6 +7,7 @@ import { loginRequiredGuard } from 'src/app/guards/login-required.guard';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { MatButtonModule } from '@angular/material/button';
+import { LoaderComponent } from 'src/app/components/loader/loader.component';
 
 const routes: Routes = [
   {
@@ -39,6 +40,7 @@ const routes: Routes = [
     MatProgressSpinnerModule,
     MatButtonModule,
     FontAwesomeModule,
+    LoaderComponent
   ],
 })
 export class DashboardModule {}

--- a/packages/frontend/src/app/pages/forum/forum.component.html
+++ b/packages/frontend/src/app/pages/forum/forum.component.html
@@ -21,7 +21,6 @@
     <mat-card [id]="'post-' + content.id" class="p-3 pb-2 mb-2 lg:mx-4 scalein wafrn-container flex-shrink-0">
       <app-post-header [fragment]="content" [simplified]="false"></app-post-header>
       <app-post-fragment [selfManageCw]="true" [fragment]="content"></app-post-fragment>
-      <hr class="dotted">
       <app-bottom-reply-bar [fragment]="content"></app-bottom-reply-bar>
     </mat-card>
     }

--- a/packages/frontend/src/app/pages/forum/forum.component.scss
+++ b/packages/frontend/src/app/pages/forum/forum.component.scss
@@ -30,8 +30,3 @@ hr {
   cursor: pointer;
   margin-left: 0px;
 }
-
-
-.dotted {
-  border-top: dotted 1px;
-}

--- a/packages/frontend/src/app/pages/login/login.component.html
+++ b/packages/frontend/src/app/pages/login/login.component.html
@@ -1,24 +1,24 @@
 <mat-card class="p-3 mb-6 lg:mx-4 scalein wafrn-container">
   <div class="text-center mb-5">
     <img loading="lazy" [src]="logo" alt="Image" height="50" class="mb-3" />
-    <div class="text-900 text-3xl font-medium mb-4">Welcome Back!</div>
-    <p class="text-900 text-xl font-medium mb-3">
+    <div class="text-3xl font-medium mb-4">Welcome Back!</div>
+    <p class="text-xl font-medium mb-3">
       <a [routerLink]="['/dashboard/explore']">
         Click here to take a look without an account!
       </a>
     </p>
     <p>
-      <span class="text-600 font-medium line-height-3"
+      <span class="font-medium line-height-3"
         >Don't have an account?</span
       >
       <a routerLink="/" class="font-medium no-underline ml-2 cursor-pointer"
         >Register now!</a
       >
     </p>
-    <p class="text-600 font-medium line-height-3">
+    <p class="font-medium line-height-3">
       If you have any issue please check your spam folder!
     </p>
-    <p class="text-600 font-medium line-height-3">
+    <p class="font-medium line-height-3">
       Still having problems? Send us an email at info &#64; wafrn.net
     </p>
   </div>

--- a/packages/frontend/src/app/pages/notifications/notifications.component.html
+++ b/packages/frontend/src/app/pages/notifications/notifications.component.html
@@ -1,16 +1,15 @@
 <div class="wafrn-container mx-1 md:mx-4 flex align-items-center">
-  <h3 class="flex-grow-1 m-0 mb-2 text-2xl ">Notifications</h3>
+  <h3 class="flex-grow-1 m-0 mb-2 text-2xl">Notifications</h3>
   <button (mousedown)=" reload()" mat-flat-button color="default" aria-label="Refresh"
     class="refresh-button" style="position: fixed; z-index: 500; top: 1em; right: 0.5em">
     <fa-icon [icon]="reloadIcon" />
   </button>
 </div>
-@if ( notificationsToShow.length === 0) {
-<app-loader></app-loader>
-
-} @for(notification of notificationsToShow; track $index) {
+<app-loader *ngIf="notificationsToShow.length === 0">notifications</app-loader>
+@for(notification of notificationsToShow; track $index) {
 <app-single-notification [notification]="notification"></app-single-notification>
 @if($index % 19 === 0 && $index > 0) {
 <!--This element is the one that says NOTIFICATION LOAD TIME-->
 <div *ngIf="$index > page * 20" class="load-more-notifications-intersector"></div>
-} }
+}
+}

--- a/packages/frontend/src/app/pages/privacy/privacy.component.html
+++ b/packages/frontend/src/app/pages/privacy/privacy.component.html
@@ -1,5 +1,5 @@
 <mat-card class="p-3 mb-6 lg:mx-4 scalein wafrn-container">
-  <div class="mb-5 text-900 font-medium">
+  <div class="mb-5 font-medium">
     <img
       loading="lazy"
       [src]="logo"

--- a/packages/frontend/src/app/pages/profile/edit-profile/edit-profile.component.html
+++ b/packages/frontend/src/app/pages/profile/edit-profile/edit-profile.component.html
@@ -1,7 +1,7 @@
 <mat-card class="p-3 mb-6 lg:mx-4 scalein wafrn-container">
   <form [hidden]="loading" [formGroup]="editProfileForm" (ngSubmit)="onSubmit()">
     <div class="pt-2 px-3 border-round-md mb-4" style="border: 1px solid #999">
-      <label for="avatar" class="block text-900 font-medium mb-2">Choose another avatar</label>
+      <label for="avatar" class="block font-medium mb-2">Choose another avatar</label>
       <input formControlName="avatar" id="avatar" type="file" accept="image/jpeg,image/png,image/webp,image/gif"
         (change)="imgSelected($event)" class="w-full mb-3" />
       </div>

--- a/packages/frontend/src/app/pages/profile/follows/follows.component.html
+++ b/packages/frontend/src/app/pages/profile/follows/follows.component.html
@@ -1,103 +1,95 @@
-@if(loading) {
-    <app-loader></app-loader>
-} @else {
-    <app-blog-header [blogDetails]="blogDetails" ></app-blog-header>
+<app-loader *ngIf="loading"></app-loader>
+<app-blog-header [blogDetails]="blogDetails" ></app-blog-header>
+<mat-card class="p-3 mb-6 lg:mx-4 scalein wafrn-container">
+    <mat-form-field class="w-full">
+      <mat-label>Search user</mat-label>
+      <input matInput class="w-full" [(ngModel)]="dataSource.filter" />
+    </mat-form-field>
+    <table mat-table [dataSource]="dataSource">
+        <ng-container matColumnDef="avatar">
+            <th mat-header-cell *matHeaderCellDef></th>
+            <td mat-cell *matCellDef="let element">
+              <app-avatar-small [user]="element"></app-avatar-small>
+            </td>
+          </ng-container>
+          <ng-container matColumnDef="url">
+            <th mat-header-cell *matHeaderCellDef>User</th>
+            <td mat-cell *matCellDef="let element">
+                <a [routerLink]="['/blog', element.url]">{{ element.url }}</a>
+              </td>
+          </ng-container>
+          <ng-container matColumnDef="date">
+            <th mat-header-cell *matHeaderCellDef>Since</th>
+            <td mat-cell *matCellDef="let element">
+              {{element.follows.createdAt | date:'short'}}
+            </td>
+          </ng-container>
+          <ng-container matColumnDef="actions">
+            <th mat-header-cell *matHeaderCellDef></th>
+            <td mat-cell *matCellDef="let element">
+              @if(!notYetAcceptedFollows.includes(element.id) && !followedUsers.includes(element.id)){
+                <button
+                mat-stroked-button
+                color="accent"
+                class="follow-button flex-shrink-0"
+                (mousedown)="postService.followUser(element.id)"
+              >
+                Follow user
+              </button>
+              }
+              @if(notYetAcceptedFollows.includes(element.id)) {
+                <button
+                mat-stroked-button
+                color="accent"
+                class="follow-button flex-shrink-0"
+                (mousedown)="postService.unfollowUser(element.id)"
+              >
+                Awaiting aproval
+              </button>
+              }
 
-    @if(blogDetails.url.startsWith('@')){
-      <h2>This is a remote user, this list is most probably incomplete</h2>
-    }
-    <mat-card class="p-3 mb-6 lg:mx-4 scalein wafrn-container">
-        <mat-form-field class="w-full">
-          <mat-label>Search user</mat-label>
-          <input matInput class="w-full" [(ngModel)]="dataSource.filter" />
-        </mat-form-field>
-      
-        <table mat-table [dataSource]="dataSource">
-            <ng-container matColumnDef="avatar">
-                <th mat-header-cell *matHeaderCellDef></th>
-                <td mat-cell *matCellDef="let element">
-                  <app-avatar-small [user]="element"></app-avatar-small>
-                </td>
-              </ng-container>
-              <ng-container matColumnDef="url">
-                <th mat-header-cell *matHeaderCellDef>User</th>
-                <td mat-cell *matCellDef="let element">
-                    <a [routerLink]="['/blog', element.url]">{{ element.url }}</a>
-                  </td>
-              </ng-container>
-              <ng-container matColumnDef="date">
-                <th mat-header-cell *matHeaderCellDef>Since</th>
-                <td mat-cell *matCellDef="let element">
-                  {{element.follows.createdAt | date:'short'}}
-                </td>
-              </ng-container>
-              <ng-container matColumnDef="actions">
-                <th mat-header-cell *matHeaderCellDef></th>
-                <td mat-cell *matCellDef="let element">
-                  @if(!notYetAcceptedFollows.includes(element.id) && !followedUsers.includes(element.id)){
-                    <button
-                    mat-stroked-button
-                    color="accent"
-                    class="follow-button flex-shrink-0"
-                    (mousedown)="postService.followUser(element.id)"
-                  >
-                    Follow user
-                  </button>
-                  }
-                  @if(notYetAcceptedFollows.includes(element.id)) {
-                    <button
-                    mat-stroked-button
-                    color="accent"
-                    class="follow-button flex-shrink-0"
-                    (mousedown)="postService.unfollowUser(element.id)"
-                  >
-                    Awaiting aproval
-                  </button>
-                  }
-                  
-                </td>
-              </ng-container>
-              <ng-container matColumnDef="removeFollower">
-                <th mat-header-cell *matHeaderCellDef></th>
-                <td  *matCellDef="let element">
-                  @if(activatedRoute.snapshot.routeConfig?.path?.toLowerCase()?.endsWith('followers') && blogDetails.id === myId) {
-                    @if(!element.follows.accepted){
-                      <button
-                    mat-mini-fab
-                    (mouseup)="acceptFollower(element)"
-                    >
-                    <fa-icon
-                    size="lg"
-                    class="cursor-pointer"
-                    [icon]="acceptIcon"
-                    matTooltip="Accept this follower"
-                  ></fa-icon>
-                  </button>
-                    }
-                    <button
-                    mat-mini-fab
-                    (mouseup)="deleteFollower(element)"
-                    >
-                    <fa-icon
-                    size="lg"
-                    class="cursor-pointer"
-                    [icon]="deleteIcon"
-                    matTooltip="Remove this follower"
-                  ></fa-icon>
-                  </button>
-                  }
-                </td>
-              </ng-container>
+            </td>
+          </ng-container>
+          <ng-container matColumnDef="removeFollower">
+            <th mat-header-cell *matHeaderCellDef></th>
+            <td  *matCellDef="let element">
+              @if(activatedRoute.snapshot.routeConfig?.path?.toLowerCase()?.endsWith('followers') && blogDetails.id === myId) {
+                @if(!element.follows.accepted){
+                  <button
+                mat-mini-fab
+                (mouseup)="acceptFollower(element)"
+                >
+                <fa-icon
+                size="lg"
+                class="cursor-pointer"
+                [icon]="acceptIcon"
+                matTooltip="Accept this follower"
+              ></fa-icon>
+              </button>
+                }
+                <button
+                mat-mini-fab
+                (mouseup)="deleteFollower(element)"
+                >
+                <fa-icon
+                size="lg"
+                class="cursor-pointer"
+                [icon]="deleteIcon"
+                matTooltip="Remove this follower"
+              ></fa-icon>
+              </button>
+              }
+            </td>
+          </ng-container>
 
-              <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-              <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
-        </table>
+          <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+          <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+    </table>
 
-        <mat-paginator
-        [pageSizeOptions]="[10, 25, 50, 100]"
-        showFirstLastButtons
-        aria-label="Select page of periodic elements"
-      >
-      </mat-paginator>
-    </mat-card>
-}
+    <mat-paginator
+    [pageSizeOptions]="[10, 25, 50, 100]"
+    showFirstLastButtons
+    aria-label="Select page of periodic elements"
+  >
+  </mat-paginator>
+</mat-card>

--- a/packages/frontend/src/app/pages/profile/import-followers/import-followers.component.html
+++ b/packages/frontend/src/app/pages/profile/import-followers/import-followers.component.html
@@ -23,10 +23,11 @@
       </button>
     </div>
 
-    <div *ngIf="uploading" class="grid w-full">
-      <mat-spinner color="accent" diameter="42"></mat-spinner>
+    <div *ngIf="uploading" class="w-full flex flex-column align-items-center gap-3">
+      <mat-spinner color="accent" diameter="32"></mat-spinner>
       <p class="m-0 text-lg text-600">Uploading... This might take some time</p>
     </div>
+
     } @case (1) {
     <button
       (mousedown)="followEveryone()"

--- a/packages/frontend/src/app/pages/profile/import-followers/import-followers.component.html
+++ b/packages/frontend/src/app/pages/profile/import-followers/import-followers.component.html
@@ -45,7 +45,7 @@
     <p [innerText]="user"></p>
     } } } @case (2) {
     <mat-spinner color="accent" diameter="42"></mat-spinner>
-    <p class="m-0 text-lg text-600">
+    <p class="m-0 text-lg">
       Following people... This might take some time
     </p>
     <mat-progress-bar

--- a/packages/frontend/src/app/pages/recover-password/recover-password.component.html
+++ b/packages/frontend/src/app/pages/recover-password/recover-password.component.html
@@ -1,20 +1,20 @@
 <mat-card class="p-3 mb-6 lg:mx-4 scalein wafrn-container">
   <div class="text-center mb-5">
     <img loading="lazy" [src]="logo" alt="Image" height="50" class="mb-3" />
-    <p class="text-900 text-3xl font-medium mb-3">
+    <p class="text-3xl font-medium mb-3">
       Don't worry, we also forget a lot of things
     </p>
-    <p class="text-600 font-medium line-height-3">
+    <p class="font-medium line-height-3">
       But you should try a password manager!
     </p>
     <p>
-      <span class="text-600 font-medium line-height-3"
+      <span class="font-medium line-height-3"
         >Don't have an account?</span
       >
       <a routerLink="/register" class="font-medium ml-2">Register now!</a>
     </p>
     <p>
-      <span class="text-600 font-medium line-height-3"
+      <span class="font-medium line-height-3"
         >Did you just remembered your password?</span
       >
       <a routerLink="/" class="font-medium ml-2">Thats great! log in now!</a>

--- a/packages/frontend/src/app/pages/register/register.component.html
+++ b/packages/frontend/src/app/pages/register/register.component.html
@@ -1,10 +1,10 @@
 <mat-card class="p-3 mb-6 lg:mx-4 scalein wafrn-container">
   <div class="text-center mb-5">
     <img loading="lazy" [src]="logo" alt="Image" height="50" class="mb-3" />
-    <div class="text-900 text-3xl font-medium mb-3">
+    <div class="text-3xl font-medium mb-3">
       Welcome! We hope you enjoy this place!
     </div>
-    <span class="text-600 font-medium line-height-3">Do you have an account?</span>
+    <span class="font-medium line-height-3">Do you have an account?</span>
     <a routerLink="/login" class="font-medium no-underline ml-2 cursor-pointer">Just log in!</a>
   </div>
 
@@ -110,7 +110,7 @@
       </mat-select>
     </mat-form-field>
     <div class="pt-2 px-3 pb-2 border-round-md" style="border: 1px solid #999">
-      <label for="avatar" class="block text-900 font-medium mb-2">Upload your avatar</label>
+      <label for="avatar" class="block font-medium mb-2">Upload your avatar</label>
       <div class="flex flex-row align-content-center">
         <button type="button" mat-stroked-button color="primary" (click)="avatarInput.click()">
           <fa-icon [icon]="faUpload" class="m-1"></fa-icon>Choose File</button>

--- a/packages/frontend/src/app/pages/reset-password/reset-password.component.html
+++ b/packages/frontend/src/app/pages/reset-password/reset-password.component.html
@@ -1,8 +1,8 @@
 <mat-card class="p-3 mb-6 lg:mx-4 scalein wafrn-container">
   <div class="text-center mb-5">
     <img [src]="logo" alt="Image" height="50" class="mb-3" />
-    <div class="text-900 text-3xl font-medium mb-3">Set a new password</div>
-    <span class="text-600 font-medium line-height-3"
+    <div class="text-3xl font-medium mb-3">Set a new password</div>
+    <span class="font-medium line-height-3"
       >And just log in after that!</span
     >
     <br />

--- a/packages/frontend/src/app/pages/search/search.component.html
+++ b/packages/frontend/src/app/pages/search/search.component.html
@@ -2,7 +2,7 @@
   <!-- SEARCH FORM -->
   <div class="pb-4 lg:px-4">
     <mat-card>
-      <div class="p-3 text-600 font-medium line-height-3">
+      <div class="p-3 font-medium line-height-3">
         <p>
           You can search for users by url and description, and posts by tags. No
           need to add # to your search. To force the server to search for a
@@ -93,6 +93,6 @@
   class="p-4 flex gap-3 align-items-center"
 >
   <mat-spinner *ngIf="loading" diameter="42"></mat-spinner>
-  <p *ngIf="loading" class="m-0 text-lg text-600">Loading more...</p>
-  <p *ngIf="posts.length === 0" class="m-0 text-lg text-600">No new results</p>
+  <p *ngIf="loading" class="m-0 text-lg">Loading more...</p>
+  <p *ngIf="posts.length === 0" class="m-0 text-lg">No new results</p>
 </footer>

--- a/packages/frontend/src/app/pages/search/search.component.html
+++ b/packages/frontend/src/app/pages/search/search.component.html
@@ -92,7 +92,7 @@
   *ngIf="atLeastOneSearchDone"
   class="p-4 flex gap-3 align-items-center"
 >
-  <mat-spinner *ngIf="loading" diameter="42"></mat-spinner>
+  <mat-spinner *ngIf="loading" diameter="24"></mat-spinner>
   <p *ngIf="loading" class="m-0 text-lg">Loading more...</p>
   <p *ngIf="posts.length === 0" class="m-0 text-lg">No new results</p>
 </footer>

--- a/packages/frontend/src/app/pages/view-blog/view-blog.component.html
+++ b/packages/frontend/src/app/pages/view-blog/view-blog.component.html
@@ -1,34 +1,32 @@
-@if(blogDetails) {
-<app-blog-header [blogDetails]="blogDetails" ></app-blog-header>
-
-<div *ngFor="let post of posts; let indexOfelement = index">
-  <ng-template> </ng-template>
-  <app-post [post]="post"></app-post>
-</div>
-<footer class="p-4 flex gap-3 align-items-center">
-  <mat-spinner *ngIf="!noMorePosts" diameter="42"></mat-spinner>
-  <p
-    [hidden]="loading || noMorePosts"
-    id="if-you-see-this-load-more-posts"
-    class="m-0 text-lg text-600"
-  >
-    Loading more...
-  </p>
-  <p *ngIf="loading" class="m-0 text-lg text-600">Loading more posts</p>
-  <p *ngIf="noMorePosts" class="m-0 text-lg text-600">
-    No more posts.<a
-      *ngIf="blogDetails.url.startsWith('@')"
-      [href]="blogDetails.remoteId"
-      target="_blank"
-      >This is an external user, there might be more posts in their profile.
-      Click here to go to their original instance</a
-    >.
-  </p>
-</footer>
-} @if(loading && !blogDetails) {
-<app-loader></app-loader>
-} @if(!loading && !found) {
+<app-loader *ngIf="loading && !blogDetails"></app-loader>
+@if(!loading && !found) {
 <app-pagenotfound />
+}
+@if(blogDetails) {
+<app-blog-header [blogDetails]="blogDetails"></app-blog-header>
+@for (post of posts; track $index) {
+  <ng-template></ng-template>
+  <app-post [post]="post"></app-post>
+}
+<footer class="p-4 flex gap-3 align-items-center wafrn-container">
+  <div [hidden]="loading || noMorePosts" id="if-you-see-this-load-more-posts"></div>
+  <mat-spinner *ngIf="!noMorePosts" diameter="24"></mat-spinner>
+  <p *ngIf="loading" class="m-0 text-lg">Loading more posts</p>
+  <div *ngIf="noMorePosts">
+    <p class="text-lg">
+      No more posts...
+    </p>
+    <p class="text-sm">
+      As this user is from a remote instance, the shown information may be incomplete.<br>
+      <a
+        *ngIf="blogDetails.url.startsWith('@')"
+        [href]="blogDetails.remoteId"
+        target="_blank"
+        >View on remote instance</a
+      >.
+    </p>
+  </div>
+</footer>
 }
 
 <button

--- a/packages/frontend/src/app/pages/view-blog/view-blog.component.html
+++ b/packages/frontend/src/app/pages/view-blog/view-blog.component.html
@@ -5,26 +5,24 @@
 @if(blogDetails) {
 <app-blog-header [blogDetails]="blogDetails"></app-blog-header>
 @for (post of posts; track $index) {
-  <ng-template></ng-template>
-  <app-post [post]="post"></app-post>
+<ng-template></ng-template>
+<app-post [post]="post"></app-post>
 }
-<footer class="p-4 flex gap-3 align-items-center wafrn-container">
-  <div [hidden]="loading || noMorePosts" id="if-you-see-this-load-more-posts"></div>
-  <mat-spinner *ngIf="!noMorePosts" diameter="24"></mat-spinner>
-  <p *ngIf="loading" class="m-0 text-lg">Loading more posts</p>
+<app-loader *ngIf="loading">posts</app-loader>
+<footer class="p-4 text-center wafrn-container">
+  <div
+    [hidden]="loading || noMorePosts"
+    id="if-you-see-this-load-more-posts"
+  ></div>
   <div *ngIf="noMorePosts">
-    <p class="text-lg">
-      No more posts...
-    </p>
-    <p class="text-sm">
-      As this user is from a remote instance, the shown information may be incomplete.<br>
-      <a
-        *ngIf="blogDetails.url.startsWith('@')"
-        [href]="blogDetails.remoteId"
-        target="_blank"
+    <p class="mb-4 text-lg">No more posts...</p>
+    <app-info-card *ngIf="blogDetails.url.startsWith('@')" [type]="infoAlert"
+      >As this user is from a remote instance, the shown information may be
+      incomplete.
+      <a [href]="blogDetails.url.split('@').length == 3 ? blogDetails.remoteId : ('https://bsky.app/profile/' + blogDetails.url.split('@')[1])" target="_blank"
         >View on remote instance</a
-      >.
-    </p>
+      >
+    </app-info-card>
   </div>
 </footer>
 }

--- a/packages/frontend/src/app/pages/view-blog/view-blog.component.ts
+++ b/packages/frontend/src/app/pages/view-blog/view-blog.component.ts
@@ -16,6 +16,7 @@ import {
   faUserSlash,
   faVolumeMute,
   faVolumeUp,
+  faExclamationTriangle,
 } from '@fortawesome/free-solid-svg-icons';
 import { Subscription, filter } from 'rxjs';
 import { ProcessedPost } from 'src/app/interfaces/processed-post';
@@ -62,6 +63,7 @@ export class ViewBlogComponent implements OnInit, OnDestroy {
   quickReblogIcon = faClockRotateLeft;
   reportIcon = faTriangleExclamation;
   homeIcon = faHome;
+  infoAlert = faExclamationTriangle;
 
   constructor(
     private activatedRoute: ActivatedRoute,

--- a/packages/frontend/src/app/pages/view-blog/view-blog.module.ts
+++ b/packages/frontend/src/app/pages/view-blog/view-blog.module.ts
@@ -11,6 +11,7 @@ import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { MatMenuModule } from '@angular/material/menu';
 import { LoaderComponent } from 'src/app/components/loader/loader.component';
 import { BlogHeaderComponent } from "../../components/blog-header/blog-header.component";
+import { InfoCardComponent } from 'src/app/components/info-card/info-card.component';
 const routes: Routes = [
   {
     path: ':url',
@@ -39,7 +40,8 @@ const routes: Routes = [
     FontAwesomeModule,
     MatMenuModule,
     LoaderComponent,
-    BlogHeaderComponent
+    BlogHeaderComponent,
+    InfoCardComponent
 ],
 })
 export class ViewBlogModule {}

--- a/packages/frontend/src/app/styles/quil.scss
+++ b/packages/frontend/src/app/styles/quil.scss
@@ -1,0 +1,113 @@
+@media (prefers-color-scheme: light) {
+  /* TODO: nuke quill-editor I never wanna see it again */
+  quill-editor * {
+    color: black !important;
+  }
+}
+
+// QL stuff to nuke later
+$editor-buttons: #ffffffde;
+
+.ql-snow .ql-stroke {
+  fill: none;
+  stroke: $editor-buttons;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 2;
+}
+
+.ql-snow .ql-fill,
+.ql-snow .ql-stroke.ql-fill {
+  fill: $editor-buttons;
+}
+
+.ql-snow .ql-picker {
+  color: $editor-buttons;
+}
+
+.uploadImageButton {
+  color: $editor-buttons;
+}
+
+.ql-snow.ql-container {
+  border-radius: 0 0 5px 5px;
+  border-color: #999;
+}
+
+.ql-snow > .ql-editor {
+  color: white;
+  font-size: 1.25em !important;
+  border-radius: 0 0 5px 5px;
+  font-size: 1em;
+  min-height: 140px;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.ql-snow > .ql-editor.ql-blank::before {
+  color: white;
+  opacity: 0.5;
+}
+
+.ql-editor:focus {
+  background-color: var(--mdc-filled-text-field-container-color);
+}
+
+.ql-mention-list-item {
+  margin: 0;
+}
+
+.ql-mention-list-item.selected {
+  background-color: #20262e;
+}
+
+.ql-picker-options {
+  background-color: var(--mdc-filled-text-field-container-color) !important;
+}
+
+.ql-tooltip {
+  z-index: 999 !important;
+}
+
+.ql-toolbar.ql-snow {
+  border-color: #999;
+}
+
+.quill-mention-inner {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+
+  img {
+    object-fit: contain;
+    width: 24px;
+    height: 24px;
+    display: block;
+    margin: 0 auto;
+  }
+}
+
+.ql-size-small {
+  font-size: 0.75em;
+  font-size: 1em;
+}
+
+.ql-size-large {
+  font-size: 2.5em;
+}
+
+.ql-size-huge {
+  font-size: 3.5em;
+}
+
+.ql-align-center {
+  text-align: center;
+}
+
+.ql-align-right {
+  text-align: right;
+}
+
+.ql-align-justify {
+  text-align: justify;
+}

--- a/packages/frontend/src/styles.scss
+++ b/packages/frontend/src/styles.scss
@@ -1,104 +1,52 @@
 @use "@angular/material" as mat;
-
-//$font-family: sans-serif;
-// Define a dark theme
-$dark-theme: mat.define-theme(
-  (
-    color: (
-      theme-type: dark,
-      primary: mat.$violet-palette,
-    ),
-    /* typography: (
-      brand-family: mat.$font-family,
-      plain-family: mat.$font-family,
-      bold-weight: 900,
-    ), */
-  )
-);
-
-$light-theme: mat.define-theme(
-  (
-    color: (
-      theme-type: light,
-      primary: mat.$violet-palette,
-    ),
-    /*
-      typography: (brand-family: $font-family,
-        plain-family: $font-family,
-        bold-weight: 900,
-      )*/
-  )
-);
-
-:root {
-  --bgcolor: #151116;
-  --cardcolor: #2a323d;
-  --wafrn-blue: rgb(56, 254, 241);
-}
-
-@include mat.elevation-classes();
-@include mat.app-background();
+@use "./app/styles/quil.scss";
 
 html {
+  color-scheme: light dark;
+  @include mat.theme(
+    (
+      color: mat.$violet-palette,
+      density: 0,
+    )
+  );
+}
+
+// HACK: Have to make dummy theme to initialize typography
+$theme: mat.define-theme(
+  (
+    color: (
+      primary: mat.$violet-palette,
+    ),
+  )
+);
+
+@include mat.typography-hierarchy($theme);
+
+:root {
+  --mat-sys-background: light-dark(#ffffff, #151116);
+  --mat-sys-surface-container-low: light-dark(#f8f2f6, #2a313c);
+  --wafrn-blue: light-dark(#125e59, #39fef1);
+  --mat-sys-label-small-size: 0.688rem;
+}
+
+html {
+  background-color: var(--mat-sys-surface);
   overflow-wrap: break-word;
-  @include mat.theme($dark-theme);
-  // Apply the dark theme by default
-  @include mat.elevation-classes();
-  @include mat.app-background();
-  @include mat.all-component-typographies($dark-theme);
-  @include mat.all-component-themes($dark-theme);
-  //font-family: $font-family;
-  //background-color: var(--bgcolor)
 }
 
 body {
   margin: 0;
 }
 
-@include mat.color-variants-backwards-compatibility($dark-theme);
-// typography styles could be included too
-@include mat.typography-hierarchy($dark-theme);
-
-@media (prefers-color-scheme: light) {
-  :root {
-    --bgcolor: unset;
-    --cardcolor: unset;
-    --wafrn-blue: rgb(18, 95, 90);
-  }
-
-  html {
-    // Apply the dark theme by default
-    @include mat.elevation-classes();
-    @include mat.app-background();
-    @include mat.all-component-typographies($light-theme);
-    @include mat.all-component-themes($light-theme);
-    //font-family: $font-family;
-    //background-color: var(--bgcolor)
-  }
-
-  @include mat.color-variants-backwards-compatibility($light-theme);
-  @include mat.typography-hierarchy($light-theme);
-
-  /* TODO: nuke quill-editor I never wanna see it again */
-  quill-editor * {
-    color: black !important;
-  }
-}
-
 .mat-drawer-content {
   background-color: var(--bgcolor);
 }
 
-$wafrn-blue: rgb(56, 254, 241);
-// $wafrn-blue: #D6CA98; I tried but people told me not to :(
-// $wafrn-dark: rgb(18, 95, 90);
-$editor-buttons: #ffffffde;
-
-@media (min-width: 992px) {
-  .show-sidebar-menu-button {
-    display: none;
-  }
-}
+/* @media (min-width: 992px) { */
+/*   .show-sidebar-menu-button { */
+/*     display: none; */
+/*   } */
+/* } */
 
 // dirty hack because bug regarding the editor
 .cdk-overlay-pane.mat-mdc-dialog-panel {
@@ -117,56 +65,10 @@ a:visited,
   text-align: center;
 }
 
-.ql-snow .ql-stroke {
-  fill: none;
-  stroke: $editor-buttons;
-  stroke-linecap: round;
-  stroke-linejoin: round;
-  stroke-width: 2;
-}
-
-.ql-snow .ql-fill,
-.ql-snow .ql-stroke.ql-fill {
-  fill: $editor-buttons;
-}
-
-.ql-snow .ql-picker {
-  color: $editor-buttons;
-}
-
-.uploadImageButton {
-  color: $editor-buttons;
-}
-
-.ql-snow.ql-container {
-  border-radius: 0 0 5px 5px;
-  border-color: #999;
-}
-
-.ql-snow > .ql-editor {
-  color: white;
-  font-size: 1.25em !important;
-  border-radius: 0 0 5px 5px;
-  font-size: 1em;
-  min-height: 140px;
-  max-height: 400px;
-  overflow-y: auto;
-}
-
 li {
   list-style-type: inside circle;
   margin-left: 1.5em;
 }
-
-.ql-snow > .ql-editor.ql-blank::before {
-  color: white;
-  opacity: 0.5;
-}
-
-.ql-editor:focus {
-  background-color: var(--mdc-filled-text-field-container-color);
-}
-
 $avatar-length: 40px;
 
 .avatar-container {
@@ -207,23 +109,11 @@ $avatar-length: 40px;
   margin: 0;
 }
 
-.ql-mention-list-item {
-  margin: 0;
-}
-
-.ql-mention-list-item.selected {
-  background-color: #20262e;
-}
-
 .post-emoji {
   display: inline-flex;
   max-height: 1.5em;
   max-width: 1.5em;
   vertical-align: middle;
-}
-
-.ql-picker-options {
-  background-color: var(--mdc-filled-text-field-container-color) !important;
 }
 
 .font-small {
@@ -268,7 +158,9 @@ $avatar-length: 40px;
 }
 
 hr {
-  border-top: 0px;
+  border-style: solid;
+  border-width: 1px 0 0 0;
+  border-color: var(--mat-sys-outline-variant);
 }
 
 blockquote {
@@ -278,28 +170,6 @@ blockquote {
 
 .mdc-button {
   min-width: unset !important;
-}
-
-.ql-tooltip {
-  z-index: 999 !important;
-}
-
-.ql-toolbar.ql-snow {
-  border-color: #999;
-}
-
-.quill-mention-inner {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-
-  img {
-    object-fit: contain;
-    width: 24px;
-    height: 24px;
-    display: block;
-    margin: 0 auto;
-  }
 }
 
 .share-button {
@@ -341,35 +211,10 @@ blockquote {
   max-height: 128px;
 }
 
-.ql-size-small {
-  font-size: 0.75em;
-  font-size: 1em;
-}
-
 .wafrn-text-default {
   font-size: 1rem;
   line-height: 1.5;
   word-wrap: break-word;
-}
-
-.ql-size-large {
-  font-size: 2.5em;
-}
-
-.ql-size-huge {
-  font-size: 3.5em;
-}
-
-.ql-align-center {
-  text-align: center;
-}
-
-.ql-align-right {
-  text-align: right;
-}
-
-.ql-align-justify {
-  text-align: justify;
 }
 
 // mobile only styles
@@ -389,42 +234,14 @@ blockquote {
 .tag {
   padding: 0 6px;
   cursor: pointer;
-  background-color: var(
-    --mat-stepper-header-selected-state-icon-background-color
-  );
-  color: var(--mdc-filled-button-label-text-color) !important;
+  background-color: var(--mat-sys-primary);
+  color: var(--mat-sys-on-primary);
   text-decoration: none;
   border-radius: 5px;
   font-size: 13px;
   line-height: 16px;
   padding-top: 2px;
   word-break: break-all;
-}
-
-.mat-mdc-card,
-table,
-mat-paginator,
-.ql-mention-list-container,
-.mat-mdc-menu-panel {
-  /* background-color: var(--cardcolor) !important; */
-  --mdc-outlined-card-container-color: transparent;
-  --mdc-outlined-card-outline-color: #999999;
-  --mdc-elevated-card-container-color: #2a323d;
-  --mat-paginator-container-background-color: #2a323d;
-}
-
-@media (prefers-color-scheme: light) {
-  .mat-mdc-card,
-  table,
-  mat-paginator,
-  .ql-mention-list-container,
-  .mat-mdc-menu-panel {
-    /* background-color: var(--cardcolor) !important; */
-    --mdc-outlined-card-container-color: transparent;
-    --mdc-outlined-card-outline-color: unset;
-    --mdc-elevated-card-container-color: unset;
-    --mat-paginator-container-background-color: unset;
-  }
 }
 
 .post-danger {
@@ -470,4 +287,9 @@ pre {
 
 .force-comic-sans {
   font-family: "Comic Sans MS", cursive, sans-serif;
+}
+
+* {
+  scrollbar-color: var(--mat-sys-primary) transparent;
+  scrollbar-width: thin;
 }

--- a/packages/frontend/src/styles.scss
+++ b/packages/frontend/src/styles.scss
@@ -1,26 +1,34 @@
-@use '@angular/material' as mat;
+@use "@angular/material" as mat;
 
 //$font-family: sans-serif;
 // Define a dark theme
-$dark-theme: mat.define-theme((color: (theme-type: dark,
-        primary: mat.$violet-palette,
-      ),
-      /*
-      typography: (brand-family: $font-family,
-        plain-family: $font-family,
-        bold-weight: 900,
-      )*/
-    ));
+$dark-theme: mat.define-theme(
+  (
+    color: (
+      theme-type: dark,
+      primary: mat.$violet-palette,
+    ),
+    /* typography: (
+      brand-family: mat.$font-family,
+      plain-family: mat.$font-family,
+      bold-weight: 900,
+    ), */
+  )
+);
 
-$light-theme: mat.define-theme((color: (theme-type: light,
-        primary: mat.$violet-palette,
-      ),
-      /*
+$light-theme: mat.define-theme(
+  (
+    color: (
+      theme-type: light,
+      primary: mat.$violet-palette,
+    ),
+    /*
       typography: (brand-family: $font-family,
         plain-family: $font-family,
         bold-weight: 900,
       )*/
-    ));
+  )
+);
 
 :root {
   --bgcolor: #151116;
@@ -28,13 +36,12 @@ $light-theme: mat.define-theme((color: (theme-type: light,
   --wafrn-blue: rgb(56, 254, 241);
 }
 
-/* $bgcolor: #151116;
-$cardcolor: #2a323d; */
-
 @include mat.elevation-classes();
 @include mat.app-background();
 
 html {
+  overflow-wrap: break-word;
+  @include mat.theme($dark-theme);
   // Apply the dark theme by default
   @include mat.elevation-classes();
   @include mat.app-background();
@@ -42,11 +49,15 @@ html {
   @include mat.all-component-themes($dark-theme);
   //font-family: $font-family;
   //background-color: var(--bgcolor)
-  overflow-wrap: break-word;
+}
+
+body {
+  margin: 0;
 }
 
 @include mat.color-variants-backwards-compatibility($dark-theme);
-@include mat.typography-hierarchy($dark-theme); // typography styles could be included too
+// typography styles could be included too
+@include mat.typography-hierarchy($dark-theme);
 
 @media (prefers-color-scheme: light) {
   :root {
@@ -75,9 +86,8 @@ html {
 }
 
 .mat-drawer-content {
-  background-color: var(--bgcolor)
+  background-color: var(--bgcolor);
 }
-
 
 $wafrn-blue: rgb(56, 254, 241);
 // $wafrn-blue: #D6CA98; I tried but people told me not to :(
@@ -94,13 +104,6 @@ $editor-buttons: #ffffffde;
 .cdk-overlay-pane.mat-mdc-dialog-panel {
   max-width: 100% !important;
 }
-
-/* This little experiment sadly didn't work */
-/* .cdk-overlay-pane.mat-mdc-dialog-panel:not(app-new-editor) > * { */
-/*   margin: auto; */
-/*   max-width: 400px; */
-/* } */
-
 
 a,
 a:visited,
@@ -140,7 +143,7 @@ a:visited,
   border-color: #999;
 }
 
-.ql-snow>.ql-editor {
+.ql-snow > .ql-editor {
   color: white;
   font-size: 1.25em !important;
   border-radius: 0 0 5px 5px;
@@ -155,7 +158,7 @@ li {
   margin-left: 1.5em;
 }
 
-.ql-snow>.ql-editor.ql-blank::before {
+.ql-snow > .ql-editor.ql-blank::before {
   color: white;
   opacity: 0.5;
 }
@@ -200,7 +203,7 @@ $avatar-length: 40px;
   user-select: unset;
 }
 
-.mention>span {
+.mention > span {
   margin: 0;
 }
 
@@ -211,7 +214,6 @@ $avatar-length: 40px;
 .ql-mention-list-item.selected {
   background-color: #20262e;
 }
-
 
 .post-emoji {
   display: inline-flex;
@@ -384,11 +386,12 @@ blockquote {
   }
 }
 
-
 .tag {
   padding: 0 6px;
   cursor: pointer;
-  background-color: var(--mat-stepper-header-selected-state-icon-background-color);
+  background-color: var(
+    --mat-stepper-header-selected-state-icon-background-color
+  );
   color: var(--mdc-filled-button-label-text-color) !important;
   text-decoration: none;
   border-radius: 5px;
@@ -397,7 +400,6 @@ blockquote {
   padding-top: 2px;
   word-break: break-all;
 }
-
 
 .mat-mdc-card,
 table,
@@ -412,7 +414,6 @@ mat-paginator,
 }
 
 @media (prefers-color-scheme: light) {
-
   .mat-mdc-card,
   table,
   mat-paginator,
@@ -427,11 +428,13 @@ mat-paginator,
 }
 
 .post-danger {
-  background: repeating-linear-gradient(45deg,
-      var(--bgcolor),
-      var(--bgcolor) 10px,
-      var(--cardcolor) 10px,
-      var(--cardcolor) 20px);
+  background: repeating-linear-gradient(
+    45deg,
+    var(--bgcolor),
+    var(--bgcolor) 10px,
+    var(--cardcolor) 10px,
+    var(--cardcolor) 20px
+  );
 }
 
 .center-text {
@@ -450,10 +453,10 @@ mat-paginator,
 }
 
 pre {
-  overflow-x: scroll
+  overflow-x: scroll;
 }
 
-.mat-mdc-dialog-inner-container>.mat-mdc-dialog-surface {
+.mat-mdc-dialog-inner-container > .mat-mdc-dialog-surface {
   padding: 20px;
 }
 

--- a/packages/frontend/src/styles.scss
+++ b/packages/frontend/src/styles.scss
@@ -63,6 +63,12 @@ li {
   list-style-type: inside circle;
   margin-left: 1.5em;
 }
+
+img {
+  display: block;
+  max-height: 100%;
+}
+
 $avatar-length: 40px;
 
 .avatar-container {

--- a/packages/frontend/src/styles.scss
+++ b/packages/frontend/src/styles.scss
@@ -23,10 +23,10 @@ $theme: mat.define-theme(
 @include mat.typography-hierarchy($theme);
 
 :root {
-  --mat-sys-background: light-dark(#ffffff, #151116);
-  --mat-sys-surface-container-low: light-dark(#f8f2f6, #2a313c);
-  --wafrn-blue: light-dark(#125e59, #39fef1);
+  --wafrn-blue: light-dark(#125e59, #96d8d1);
   --mat-sys-label-small-size: 0.688rem;
+
+  --info-card-warning-background: light-dark(#d7c3b8, #52443c);
 }
 
 html {
@@ -41,12 +41,6 @@ body {
 .mat-drawer-content {
   background-color: var(--bgcolor);
 }
-
-/* @media (min-width: 992px) { */
-/*   .show-sidebar-menu-button { */
-/*     display: none; */
-/*   } */
-/* } */
 
 // dirty hack because bug regarding the editor
 .cdk-overlay-pane.mat-mdc-dialog-panel {
@@ -176,21 +170,6 @@ blockquote {
   gap: 0.5em;
 }
 
-.split-button-left {
-  border-top-right-radius: 0;
-  border-bottom-right-radius: 0;
-  min-width: 0;
-}
-
-.split-button-right {
-  width: 30px !important;
-  min-width: unset !important;
-  padding: 0 2px;
-  border-top-left-radius: 0;
-  border-bottom-left-radius: 0;
-  border-left: 1px solid #ffffff44;
-}
-
 .shortened-post {
   max-height: 1250px;
   overflow: hidden;
@@ -205,16 +184,19 @@ blockquote {
   border-radius: 0.25em;
   cursor: pointer !important;
   margin-bottom: 4px;
-  border: 1px solid #888;
+  border: 1px solid var(--mat-sys-outline);
   overflow: hidden;
   flex-shrink: 0;
   max-height: 128px;
 }
 
-.wafrn-text-default {
-  font-size: 1rem;
-  line-height: 1.5;
-  word-wrap: break-word;
+.post-text {
+  & > :first-child {
+    margin-top: 0;
+  }
+  & > :last-child {
+    margin-bottom: 0;
+  }
 }
 
 // mobile only styles
@@ -232,14 +214,14 @@ blockquote {
 }
 
 .tag {
-  padding: 0 6px;
+  padding: 0 0.75ch;
   cursor: pointer;
   background-color: var(--mat-sys-primary);
   color: var(--mat-sys-on-primary);
   text-decoration: none;
-  border-radius: 5px;
-  font-size: 13px;
-  line-height: 16px;
+  border-radius: var(--mat-sys-corner-small);
+  font-size: 0.8em;
+  line-height: 1.3;
   padding-top: 2px;
   word-break: break-all;
 }
@@ -290,6 +272,6 @@ pre {
 }
 
 * {
-  scrollbar-color: var(--mat-sys-primary) transparent;
+  scrollbar-color: var(--mat-sys-outline-variant) transparent;
   scrollbar-width: thin;
 }


### PR DESCRIPTION
Cleans up the global sheet by  and swapping the current `mdc` styles to just use `mat-sys` styles.

I also went around and fixed a ton of smaller inconsistencies including and not limited to:

- Spinner size consistency
  - Post loading ones use
- Fonts having colors that don't actually exist
- Horizontal rule element color (they were not `border-style: solid`)
- Splitting out the old quill styles to `src/app/styles/quill.scss`
- A bunch of spacing things
- Removing legacy `<hr>`s
- Making the blog pages look cooler
- Honestly way too much to remember, sorry!

I wonder what the diff on this is...