### PR TITLE
Fix small images centering

### DIFF
--- a/packages/frontend/src/app/components/wafrn-media/wafrn-media.component.html
+++ b/packages/frontend/src/app/components/wafrn-media/wafrn-media.component.html
@@ -1,6 +1,6 @@
 <div #media>
   <mat-card *ngIf="data" class="overflow-hidden mt-1" (click)="showPicture()">
-    <div (keyup)="showPicture()" class="img-container media-description bg-black-alpha-10">
+    <div (keyup)="showPicture()" class="img-container media-description">
       <div class="img-video-container">
         <b class="img-cw-text" *ngIf="nsfw">This contains sensitive content. Click to display</b>
 
@@ -29,7 +29,7 @@
         <source [src]="displayUrl" [type]="mimeType" />
       </audio>
 
-      <div *ngIf="data.description" class="px-2" [innerText]="data.description"></div>
+      <div *ngIf="data.description" class="px-2 py-1 image-description" [innerText]="data.description"></div>
     </div>
   </mat-card>
 </div>

--- a/packages/frontend/src/app/components/wafrn-media/wafrn-media.component.scss
+++ b/packages/frontend/src/app/components/wafrn-media/wafrn-media.component.scss
@@ -1,3 +1,11 @@
+mat-card {
+  background: var(--mat-sys-surface-container);
+}
+
+.image-description {
+  background: var(--mat-sys-surface-container-high);
+}
+
 img,
 video {
   max-width: 100%;
@@ -7,7 +15,6 @@ video {
 .nsfw {
   filter: grayscale(1) contrast(0%);
   background-color: grey;
-
 }
 
 .displayed-image {
@@ -31,7 +38,7 @@ video {
   left: 50%;
   transform: translate(-50%, -50%);
   z-index: 69;
-  color: white
+  color: white;
 }
 
 .img-container {

--- a/packages/frontend/src/app/components/wafrn-media/wafrn-media.component.scss
+++ b/packages/frontend/src/app/components/wafrn-media/wafrn-media.component.scss
@@ -36,5 +36,8 @@ video {
 
 .img-container {
   position: relative;
-  text-align: center;
+
+  & > img {
+    margin-inline: auto;
+  }
 }

--- a/packages/frontend/src/app/components/wafrn-media/wafrn-media.component.scss
+++ b/packages/frontend/src/app/components/wafrn-media/wafrn-media.component.scss
@@ -37,7 +37,7 @@ video {
 .img-container {
   position: relative;
 
-  & > img {
+  & img {
     margin-inline: auto;
   }
 }

--- a/packages/frontend/src/app/components/wafrn-media/wafrn-media.component.scss
+++ b/packages/frontend/src/app/components/wafrn-media/wafrn-media.component.scss
@@ -44,7 +44,8 @@ video {
 .img-container {
   position: relative;
 
-  & img {
+  & img,
+  & video {
     margin-inline: auto;
   }
 }

--- a/packages/frontend/src/styles.scss
+++ b/packages/frontend/src/styles.scss
@@ -64,7 +64,8 @@ li {
   margin-left: 1.5em;
 }
 
-img {
+img,
+video {
   display: block;
   max-height: 100%;
 }


### PR DESCRIPTION
I forgot that changing images from inline to block can break cursed styles.

It seems that images were previously centered using text-align as the default `display` mode for `img` is `inline`. This is an extremely cursed default so I have fixed it.