### PR TITLE
Restyle post usernames

### DIFF
--- a/packages/frontend/src/app/components/bottom-reply-bar/bottom-reply-bar.component.html
+++ b/packages/frontend/src/app/components/bottom-reply-bar/bottom-reply-bar.component.html
@@ -6,6 +6,10 @@
           ><b>{{ notes }}</b> notes</a
         >
       </p>
+    } @else {
+      <p class="m-0 text-sm">
+        <a [routerLink]="'/fediverse/post/' + fragment.id" class="subtle-link notes-link">View thread</a>
+      </p>
     }
   </div>
   @if (userLoggedIn) {

--- a/packages/frontend/src/app/components/bottom-reply-bar/bottom-reply-bar.component.scss
+++ b/packages/frontend/src/app/components/bottom-reply-bar/bottom-reply-bar.component.scss
@@ -4,7 +4,7 @@
   --mdc-outlined-button-outline-color: var(--mat-sys-outline-variant);
 }
 
-.notes-link {
+[mat-stroked-button].notes-link {
   padding-inline: 0.75rem;
   margin-left: -0.25rem;
 }

--- a/packages/frontend/src/app/components/post/post-header/post-header.component.html
+++ b/packages/frontend/src/app/components/post/post-header/post-header.component.html
@@ -4,20 +4,16 @@
       <div class="flex gap-2 min-w-0">
         <div class="flex gap-2 mr-auto min-w-0">
           <app-avatar-small [user]="fragment.user"></app-avatar-small>
-          <div class="flex flex-column min-w-0">
-            <div class="user-name">
-              <a
-                class="subtle-link"
-                [routerLink]="!disableLink ? '/blog/' + fragment.user.url : null"
-                [innerHTML]="fragment.user.name"
-              ></a>
-              {{ headerText }}
-            </div>
-            <span
-              class="text-sm max-w-full white-space-nowrap overflow-hidden text-overflow-ellipsis user-url"
-              [innerText]="fragment.user.url"
-            ></span>
-          </div>
+          <a
+            class="flex flex-column min-w-0 user-link"
+            [routerLink]="!disableLink ? '/blog/' + fragment.user.url : null"
+          >
+            <span class="no-underline user-name"
+              ><span [innerHTML]="fragment.user.name"></span>
+              <span class="text-sm post-action">{{ headerText }}</span></span
+            >
+            <span class="text-sm user-url" [innerText]="fragment.user.url"></span>
+          </a>
         </div>
       </div>
       <div *ngIf="!simplified" class="flex align-items-center date-line">

--- a/packages/frontend/src/app/components/post/post-header/post-header.component.scss
+++ b/packages/frontend/src/app/components/post/post-header/post-header.component.scss
@@ -1,13 +1,9 @@
-.user-name {
+.user-name,
+.user-url {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
   line-height: 1.35;
-}
-
-.user-url {
-  line-height: 1.35;
-  color: var(--mat-sys-outline);
 }
 
 .follow-button {

--- a/packages/frontend/src/app/components/post/post.component.html
+++ b/packages/frontend/src/app/components/post/post.component.html
@@ -11,11 +11,11 @@
       [time]="originalPostContent[this.originalPostContent.length - 1].createdAt"
     >
       <a
-        class="subtle-link"
+        class="user-link user-name"
         [routerLink]="'/blog/' + originalPostContent[this.originalPostContent.length - 1].user.url"
         [innerHTML]="originalPostContent[this.originalPostContent.length - 1].user.name"
       ></a>
-      {{ headerText }}
+      <span class="text-sm post-action"> {{ headerText }}</span>
     </app-post-ribbon>
   }
   <div

--- a/packages/frontend/src/app/components/single-notification/single-notification.component.html
+++ b/packages/frontend/src/app/components/single-notification/single-notification.component.html
@@ -10,33 +10,39 @@
     [card]="false"
     [time]="notification.date"
   >
-    <a [routerLink]="'/blog/' + notification.userUrl" [innerHTML]="notification.userUrl" class="subtle-link"></a>
-    @switch (notification.type) {
-      @case (notificationType.MENTION) {
-        mentioned you in a woot
-      }
-      @case (notificationType.LIKE) {
-        liked one of your woots
-      }
-      @case (notificationType.FOLLOW) {
-        now follows you!
-      }
-      @case (notificationType.REBLOG) {
-        rewooted one of your woots
-      }
-      @case (notificationType.QUOTE) {
-        quoted you in a woot
-      }
-      @case (notificationType.EMOJIREACT) {
-        reacted with
-        @if (emojiUrl) {
-          <img class="post-emoji" [src]="emojiUrl" [alt]="notification.emojiName" />
-        } @else {
-          {{ notification.emojiName }}
+    <a
+      class="user-link user-name"
+      [routerLink]="'/blog/' + notification.userUrl"
+      [innerHTML]="notification.userUrl"
+    ></a>
+    <span class="text-sm post-action">
+      @switch (notification.type) {
+        @case (notificationType.MENTION) {
+          mentioned you in a woot
         }
-        to your woot
+        @case (notificationType.LIKE) {
+          liked one of your woots
+        }
+        @case (notificationType.FOLLOW) {
+          now follows you!
+        }
+        @case (notificationType.REBLOG) {
+          rewooted one of your woots
+        }
+        @case (notificationType.QUOTE) {
+          quoted you in a woot
+        }
+        @case (notificationType.EMOJIREACT) {
+          reacted with
+          @if (emojiUrl) {
+            <img class="post-emoji" [src]="emojiUrl" [alt]="notification.emojiName" />
+          } @else {
+            {{ notification.emojiName }}
+          }
+          to your woot
+        }
       }
-    }
+    </span>
   </app-post-ribbon>
   @if (notification.type !== notificationType.FOLLOW) {
     <hr />

--- a/packages/frontend/src/app/pages/forum/forum.component.html
+++ b/packages/frontend/src/app/pages/forum/forum.component.html
@@ -35,11 +35,11 @@
       </mat-card>
     } @else {
       <app-post-ribbon [user]="content.user" [icon]="rewootIcon" [time]="content.createdAt">
-        <a class="subtle-link" [routerLink]="'/blog/' + content.user.url" [innerHTML]="content.user.name"></a>
-        rewooted
+        <a class="user-link user-name" [routerLink]="'/blog/' + content.user.url" [innerHTML]="content.user.name"></a>
+        <span class="text-sm post-action"> rewooted </span>
         <a
           [routerLink]="'/fediverse/post/' + content.parentId"
-          class="subtle-link"
+          class="user-link user-name"
           [innerHTML]="findReply(content.parentId)?.user?.name ?? 'Unknown User'"
         ></a>
       </app-post-ribbon>

--- a/packages/frontend/src/app/styles/post-card.scss
+++ b/packages/frontend/src/app/styles/post-card.scss
@@ -16,6 +16,28 @@
 }
 
 // Elements inside cards
+:root .user-link {
+  text-decoration: none;
+  color: unset;
+
+  &:hover.user-name,
+  &:hover .user-url {
+    text-decoration: underline;
+  }
+}
+
+.user-name {
+  font-weight: 500;
+}
+
+.user-url {
+  color: var(--mat-sys-outline);
+}
+
+.post-action {
+  color: var(--mat-sys-outline);
+}
+
 .post-text {
   & > :first-child {
     margin-top: 0;


### PR DESCRIPTION
Re-styles the post usernames to be their own thing instead of just links

## Before

Dashboard

![image](https://github.com/user-attachments/assets/8c12573b-6135-4302-a873-232557659514)

Notification

![image](https://github.com/user-attachments/assets/7b4fe0f3-0665-4cbb-ae01-e9f23e9016df)

Reply

![image](https://github.com/user-attachments/assets/ef37992a-5601-4c42-a10c-6b22d80c1fe1)

## After

Dashboard

![image](https://github.com/user-attachments/assets/2ea330e5-19bb-48bd-abe4-5ec84715ebda)

Notification

![image](https://github.com/user-attachments/assets/5f418f6c-e8f6-469c-aff6-e403e1a8b154)

Reply

![image](https://github.com/user-attachments/assets/647cb85b-0b38-43fe-9bc9-c9d916352f9d)
