### PR TITLE
Add light dark theme selector

### DIFF
--- a/packages/frontend/src/app/components/navigation-menu/navigation-menu.component.html
+++ b/packages/frontend/src/app/components/navigation-menu/navigation-menu.component.html
@@ -9,7 +9,7 @@
     <a [href]="'/'" class="block" (mousedown)="hideMenu()">
       <img
         [src]="logo"
-        class="block mx-auto my-3"
+        class="block mx-auto mt-3"
         alt="instance logo"
         width="200"
         style="aspect-ratio: 3 / 1; object-fit: contain"
@@ -25,6 +25,9 @@
         }
       }
     </mat-nav-list>
+    <div class="drawer-footer">
+      <app-theme-switcher></app-theme-switcher>
+    </div>
   </mat-drawer>
   <mat-drawer-content>
     <button

--- a/packages/frontend/src/app/components/navigation-menu/navigation-menu.component.scss
+++ b/packages/frontend/src/app/components/navigation-menu/navigation-menu.component.scss
@@ -1,11 +1,12 @@
 //app-navigation-menu,
 :root .side-menu {
-  display: block;
   background-color: var(--mat-sys-surface-container-low);
   box-shadow: var(--mat-sys-level2);
 }
 
 .mat-drawer-inner-container {
+  display: flex;
+  flex-direction: column;
   padding: 0.5rem;
   overscroll-behavior-y: contain;
 }
@@ -20,4 +21,10 @@
 
 hr {
   margin: 16px 0;
+}
+
+.drawer-footer {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: auto;
 }

--- a/packages/frontend/src/app/components/navigation-menu/navigation-menu.module.ts
+++ b/packages/frontend/src/app/components/navigation-menu/navigation-menu.module.ts
@@ -9,6 +9,7 @@ import { MatBadgeModule } from '@angular/material/badge'
 import { MatButtonModule } from '@angular/material/button'
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome'
 import { MatDialogModule } from '@angular/material/dialog'
+import { ThemeSwitcherComponent } from '../theme-switcher/theme-switcher.component'
 
 @NgModule({
   declarations: [NavigationMenuComponent],
@@ -21,7 +22,8 @@ import { MatDialogModule } from '@angular/material/dialog'
     MatBadgeModule,
     FontAwesomeModule,
     MatButtonModule,
-    MatDialogModule
+    MatDialogModule,
+    ThemeSwitcherComponent
   ],
   exports: [NavigationMenuComponent]
 })

--- a/packages/frontend/src/app/components/theme-switcher/theme-switcher.component.html
+++ b/packages/frontend/src/app/components/theme-switcher/theme-switcher.component.html
@@ -1,0 +1,41 @@
+<button
+  mat-button
+  [matMenuTriggerFor]="themeMenu"
+  class="theme-toggle"
+  title="Change color scheme"
+  aria-label="Change color scheme"
+  [ngClass]="iconClass"
+  matTooltip="{{ themeText() }} mode"
+>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    aria-hidden="true"
+    class="theme-toggle__within"
+    height="1.5em"
+    width="1.5em"
+    viewBox="0 0 32 32"
+    fill="currentColor"
+  >
+    <clipPath id="theme-toggle__within__clip">
+      <path d="M0 0h32v32h-32ZM6 16A1 1 0 0026 16 1 1 0 006 16" />
+    </clipPath>
+    <g clip-path="url(#theme-toggle__within__clip)">
+      <path
+        d="M30.7 21.3 27.1 16l3.7-5.3c.4-.5.1-1.3-.6-1.4l-6.3-1.1-1.1-6.3c-.1-.6-.8-.9-1.4-.6L16 5l-5.4-3.7c-.5-.4-1.3-.1-1.4.6l-1 6.3-6.4 1.1c-.6.1-.9.9-.6 1.3L4.9 16l-3.7 5.3c-.4.5-.1 1.3.6 1.4l6.3 1.1 1.1 6.3c.1.6.8.9 1.4.6l5.3-3.7 5.3 3.7c.5.4 1.3.1 1.4-.6l1.1-6.3 6.3-1.1c.8-.1 1.1-.8.7-1.4zM16 25.1c-5.1 0-9.1-4.1-9.1-9.1 0-5.1 4.1-9.1 9.1-9.1s9.1 4.1 9.1 9.1c0 5.1-4 9.1-9.1 9.1z"
+      />
+    </g>
+    <path
+      class="theme-toggle__within__circle"
+      d="M16 7.7c-4.6 0-8.2 3.7-8.2 8.2s3.6 8.4 8.2 8.4 8.2-3.7 8.2-8.2-3.6-8.4-8.2-8.4zm0 14.4c-3.4 0-6.1-2.9-6.1-6.2s2.7-6.1 6.1-6.1c3.4 0 6.1 2.9 6.1 6.2s-2.7 6.1-6.1 6.1z"
+    />
+    <path
+      class="theme-toggle__within__inner"
+      d="M16 9.5c-3.6 0-6.4 2.9-6.4 6.4s2.8 6.5 6.4 6.5 6.4-2.9 6.4-6.4-2.8-6.5-6.4-6.5z"
+    />
+  </svg>
+</button>
+<mat-menu #themeMenu="matMenu">
+  <button mat-menu-item (click)="setTheme('light')">Light</button>
+  <button mat-menu-item (click)="setTheme('dark')">Dark</button>
+  <button mat-menu-item (click)="setTheme('auto')">Auto</button>
+</mat-menu>

--- a/packages/frontend/src/app/components/theme-switcher/theme-switcher.component.scss
+++ b/packages/frontend/src/app/components/theme-switcher/theme-switcher.component.scss
@@ -1,0 +1,8 @@
+.theme-toggle {
+  padding: 0;
+  aspect-ratio: 1 / 1;
+}
+
+svg {
+  display: block;
+}

--- a/packages/frontend/src/app/components/theme-switcher/theme-switcher.component.ts
+++ b/packages/frontend/src/app/components/theme-switcher/theme-switcher.component.ts
@@ -1,0 +1,58 @@
+import { Component, linkedSignal, signal } from '@angular/core'
+import { MatMenuModule } from '@angular/material/menu'
+import { MatButtonModule } from '@angular/material/button'
+import { NgClass } from '@angular/common'
+import { MatTooltipModule } from '@angular/material/tooltip'
+
+type ColorTheme = 'light' | 'dark' | 'auto'
+
+function capitalize(text: string) {
+  text = text[0].toUpperCase() + text.slice(1)
+  return text
+}
+
+@Component({
+  selector: 'app-theme-switcher',
+  imports: [NgClass, MatMenuModule, MatButtonModule, MatTooltipModule],
+  templateUrl: './theme-switcher.component.html',
+  styleUrl: './theme-switcher.component.scss'
+})
+export class ThemeSwitcherComponent {
+  // Light/Dark mode
+  theme = signal<ColorTheme>(this.getTheme())
+  themeText = linkedSignal(() => capitalize(this.theme()))
+  iconClass = ''
+
+  constructor() {
+    this.setTheme(this.theme())
+    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', this.updateIconTheme.bind(this))
+  }
+
+  getTheme(): ColorTheme {
+    if (typeof localStorage !== 'undefined') {
+      const localTheme = localStorage.getItem('theme')
+      if (localTheme === 'light' || localTheme === 'dark' || localTheme === 'auto') {
+        return localTheme
+      }
+    }
+    return 'auto'
+  }
+
+  setTheme(theme: ColorTheme) {
+    this.theme.set(theme)
+    document.documentElement.setAttribute('data-theme', theme)
+    window.localStorage.setItem('theme', theme)
+    this.updateIconTheme()
+  }
+
+  updateIconTheme() {
+    if (
+      this.theme() === 'dark' ||
+      (this.theme() === 'auto' && window.matchMedia('(prefers-color-scheme: dark)').matches)
+    ) {
+      this.iconClass = 'theme-toggle--toggled'
+    } else {
+      this.iconClass = ''
+    }
+  }
+}

--- a/packages/frontend/src/app/styles/theme-switcher.scss
+++ b/packages/frontend/src/app/styles/theme-switcher.scss
@@ -1,0 +1,62 @@
+// Theme switcher styles
+html[data-theme='light'] {
+  color-scheme: light;
+}
+html[data-theme='dark'] {
+  color-scheme: dark;
+}
+html[data-theme='auto'] {
+  color-scheme: light dark;
+}
+
+// From toggles.dev
+.theme-toggle.theme-toggle--reversed .theme-toggle__within {
+  transform: scale(-1, 1);
+}
+
+.theme-toggle {
+  --theme-toggle__within--duration: 500ms;
+}
+.theme-toggle__within * {
+  transform-origin: center;
+  transition: transform calc(var(--theme-toggle__within--duration)) cubic-bezier(0, 0, 0, 1.25);
+}
+
+.theme-toggle--toggled:not(label).theme-toggle .theme-toggle__within .theme-toggle__within__circle,
+.theme-toggle input[type='checkbox']:checked ~ .theme-toggle__within .theme-toggle__within__circle {
+  transform: scale(1.5);
+}
+.theme-toggle--toggled:not(label).theme-toggle .theme-toggle__within .theme-toggle__within__inner,
+.theme-toggle input[type='checkbox']:checked ~ .theme-toggle__within .theme-toggle__within__inner {
+  transform: translate3d(3px, -3px, 0) scale(1.2);
+}
+.theme-toggle--toggled:not(label).theme-toggle .theme-toggle__within g path,
+.theme-toggle input[type='checkbox']:checked ~ .theme-toggle__within g path {
+  transform: scale(0.65);
+}
+
+.theme-toggle {
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+.theme-toggle input[type='checkbox'] {
+  display: none;
+}
+.theme-toggle .theme-toggle-sr {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .theme-toggle:not(.theme-toggle--force-motion) * {
+    transition: none !important;
+  }
+}

--- a/packages/frontend/src/index.html
+++ b/packages/frontend/src/index.html
@@ -31,6 +31,17 @@
     <link rel="apple-touch-icon" href="/assets/icons/icon-512x512.png" />
     <link rel="manifest" href="manifest.webmanifest" />
     <meta name="theme-color" content="#20262e" />
+    <script>
+      // Theme switcher bootstrap
+      if (typeof localStorage !== 'undefined') {
+        const localTheme = localStorage.getItem('theme')
+        if (localTheme === 'light' || localTheme === 'dark' || localTheme === 'auto') {
+          document.documentElement.setAttribute('data-theme', localTheme)
+        }
+      } else {
+        document.documentElement.setAttribute('data-theme', 'auto')
+      }
+    </script>
   </head>
   <body class="mat-typography mat-app-background">
     <noscript>

--- a/packages/frontend/src/styles.scss
+++ b/packages/frontend/src/styles.scss
@@ -2,6 +2,7 @@
 @use './app/styles/quil.scss';
 @use './app/styles/post-card.scss';
 @use './app/styles/basic-html.scss';
+@use './app/styles/theme-switcher.scss';
 
 html {
   color-scheme: light dark;


### PR DESCRIPTION
Adds a theme selector. By default it uses 'auto'. Users may select Light or Dark to force that theme.

I also added a bootstrap so we don't get a FOUC flashbang.

Icon via https://toggles.dev

![image](https://github.com/user-attachments/assets/0b12fccf-56ac-40d9-acac-1951c0629c2b)
