### PR TITLE
Fix video and audio alt text

### DIFF
--- a/packages/frontend/src/app/components/wafrn-media/wafrn-media.component.scss
+++ b/packages/frontend/src/app/components/wafrn-media/wafrn-media.component.scss
@@ -76,6 +76,8 @@ video {
   .always-show-alt & {
     position: static;
     opacity: 1;
+    max-height: 10rem;
+    visibility: visible;
   }
 }
 


### PR DESCRIPTION
I messed up and didn't make them `visibility: visible`. I also added a max-height of 10 rem so people can't nuke your page with the Bee Movie script as alt text.

## Before

![image](https://github.com/user-attachments/assets/69a279f7-dd32-4046-9e3d-b781f82bc210)

## After

![image](https://github.com/user-attachments/assets/b752ab45-04f2-484b-b6d8-acf7bb2824a1)

### Testing the bee movie script

![image](https://github.com/user-attachments/assets/c8e96603-5270-4950-985d-8a4038057f81)