### PR TITLE
fix: mention highlighting targeting wafrn links

### DIFF
--- a/packages/frontend/src/app/services/posts.service.ts
+++ b/packages/frontend/src/app/services/posts.service.ts
@@ -412,21 +412,31 @@ export class PostsService {
         const sanitizedContent = sanitizeHtml(link.innerHTML, {
           allowedTags: []
         })
-        if (
-          sanitizedContent.startsWith('@') &&
-          mentionRemoteUrls.includes(`${sanitizedContent}@${linkAsUrl.hostname}`)
-        ) {
-          link.href = `/blog/${sanitizedContent}@${linkAsUrl.hostname}`
+        const isUserTag = sanitizedContent.startsWith('@')
+        const isRemoteUser = mentionRemoteUrls.includes(`${sanitizedContent}@${linkAsUrl.hostname}`)
+        const isLocalUser = mentionRemoteUrls.includes(`${sanitizedContent}`)
+        const isLocalUserLink =
+          linkAsUrl.hostname === hostUrl &&
+          (linkAsUrl.pathname.startsWith('/blog') || linkAsUrl.pathname.startsWith('/fediverse/blog'))
+
+        if (isUserTag) {
           link.classList.add('mention')
-          link.classList.add('remote-mention')
+
+          if (isRemoteUser) {
+            // Remote blog, mirror to local blog
+            link.href = `/blog/${sanitizedContent}@${linkAsUrl.hostname}`
+            link.classList.add('remote-mention')
+          }
+
+          if (isLocalUser) {
+            //link.href = `/blog/${sanitizedContent}`
+            link.classList.add('mention')
+            link.classList.add('local-mention')
+          }
         }
-        if (
-          (sanitizedContent.startsWith('@') && mentionRemoteUrls.includes(`${sanitizedContent}`)) ||
-          linkAsUrl.hostname === hostUrl
-        ) {
-          //link.href = `/blog/${sanitizedContent}`
-          link.classList.add('mention')
-          link.classList.add('local-mention')
+        // Also tag local user links for user styles
+        if (isLocalUserLink) {
+          link.classList.add('local-user-link')
         }
       }
       link.target = '_blank'


### PR DESCRIPTION
Fixes mentions highlighting *all* wafrn links instead of just `@` user mentions. Also refactors the post service file's function for fun and more clarity.

If the old behavior looks cooler, I also added the `local-user-link` to all user blog page links (second message in example images)

## Before

![image](https://github.com/user-attachments/assets/ae028855-f8de-410c-ab07-fa7a8ea21347)

## After

![image](https://github.com/user-attachments/assets/8ac8ea35-cdd4-4d69-9b73-5fc4a4857728)
