### PR TITLE
Increase contrast of menu containers

### DIFF
--- a/packages/frontend/src/app/styles/material-overrides.scss
+++ b/packages/frontend/src/app/styles/material-overrides.scss
@@ -1,3 +1,8 @@
+// Colors
+:root {
+  --mat-menu-container-color: var(--mat-sys-surface-container-high);
+}
+
 // Allow tiny buttons
 .mdc-button {
   min-width: unset !important;


### PR DESCRIPTION
Uses the `high` color instead of the normal one for higher contrast.

## Before

![image](https://github.com/user-attachments/assets/64969ccd-fedd-4456-bd60-8b661090ce03)

## After

(on an older branch without color schemes)

![image](https://github.com/user-attachments/assets/3e33b0a5-1eae-46ea-88d0-a90135b94ed1)
