### PR TITLE
feat: add tab navigation to sidebar

### DIFF
--- a/packages/frontend/src/app/components/menu-item/menu-item.component.html
+++ b/packages/frontend/src/app/components/menu-item/menu-item.component.html
@@ -1,6 +1,6 @@
 @if (item.visible) {
   @if (item.items) {
-    <a mat-list-item (mousedown)="expanded = !expanded">
+    <a mat-list-item (mousedown)="expanded = !expanded" (keydown)="handleKey($event)" tabIndex="0">
       <div class="h-3rem flex align-items-center justify-content-start">
         <span
           [matBadge]="item.badge"
@@ -25,7 +25,13 @@
       </div>
     }
   } @else {
-    <a mat-list-item [routerLink]="item.routerLink ? item.routerLink : null" (mousedown)="doCommand()">
+    <a
+      mat-list-item
+      [routerLink]="item.routerLink ? item.routerLink : null"
+      (mousedown)="doCommand()"
+      (keydown)="handleKey($event)"
+      tabIndex="0"
+    >
       <div class="h-3rem flex align-items-center justify-content-start">
         <span
           [matBadge]="item.badge"

--- a/packages/frontend/src/app/components/menu-item/menu-item.component.ts
+++ b/packages/frontend/src/app/components/menu-item/menu-item.component.ts
@@ -37,4 +37,15 @@ export class MenuItemComponent {
       this.item.command()
     }
   }
+
+  handleKey(event: KeyboardEvent) {
+    if (event.key !== 'Enter') return
+
+    // Run the associated event
+    if (this.item.items) {
+      this.expanded = !this.expanded
+    } else {
+      this.doCommand()
+    }
+  }
 }


### PR DESCRIPTION
Fixes #234 

Adds a `tabstop` to the sidebar elements to make them tabbable on all browsers and a handler for keydowns.

Pressing the enter key will now select the menu option, either running the command or expanding/collapsing a section.

## Before

(didn't work)

## After

https://github.com/user-attachments/assets/89e0b290-e39f-4748-ad54-6676be0df717


