### PR TITLE
Fix emojis included in media preview

### DIFF
--- a/packages/frontend/src/app/components/post-fragment/post-fragment.component.html
+++ b/packages/frontend/src/app/components/post-fragment/post-fragment.component.html
@@ -18,7 +18,6 @@
   </button>
 }
 <div
-  #media
   class="flex flex-column gap-3 post-content"
   [ngClass]="{
     'post-danger': (fragment.content_warning || fragment.muted_words_cw) && showCw,
@@ -27,6 +26,7 @@
 >
   @for (block of wafrnFormattedContent; track $index) {
     <div
+      #mediaInline
       class="fragment-content overflow-hidden"
       [ngClass]="{ blurry: (fragment.content_warning || fragment.muted_words_cw) && showCw }"
     >
@@ -43,7 +43,7 @@
   >
     <app-poll [poll]="fragment.questionPoll"></app-poll>
   </div>
-  <section class="flex flex-column gap-3">
+  <section #mediaEnd class="flex flex-column gap-3">
     @for (media of fragment.medias; track $index) {
       <div [ngClass]="{ blurry: (fragment.content_warning || fragment.muted_words_cw) && showCw }">
         <app-wafrn-media *ngIf="!seenMedia.includes($index)" [data]="media"></app-wafrn-media>

--- a/packages/frontend/src/app/components/post-fragment/post-fragment.component.ts
+++ b/packages/frontend/src/app/components/post-fragment/post-fragment.component.ts
@@ -80,7 +80,8 @@ export class PostFragmentComponent implements OnChanges, OnDestroy {
 
   readonly inlineMediaElement = viewChild<ElementRef<HTMLElement>>('mediaInline')
   readonly endMediaElement = viewChild<ElementRef<HTMLElement>>('mediaEnd')
-  viewer: Viewer | undefined
+  viewerInline: Viewer | undefined
+  viewerEnd: Viewer | undefined
 
   constructor(
     private postService: PostsService,
@@ -344,14 +345,14 @@ export class PostFragmentComponent implements OnChanges, OnDestroy {
   }
 
   ngAfterViewInit(): void {
-    this.attachViewer(this.inlineMediaElement())
-    this.attachViewer(this.endMediaElement())
+    this.viewerInline = this.attachViewer(this.inlineMediaElement())
+    this.viewerEnd = this.attachViewer(this.endMediaElement())
   }
 
   attachViewer(container: ElementRef<HTMLElement> | undefined) {
     if (!container) return
 
-    this.viewer = new Viewer(container.nativeElement, {
+    return new Viewer(container.nativeElement, {
       button: true,
       navbar: true,
       toolbar: {

--- a/packages/frontend/src/app/components/post-fragment/post-fragment.component.ts
+++ b/packages/frontend/src/app/components/post-fragment/post-fragment.component.ts
@@ -78,7 +78,8 @@ export class PostFragmentComponent implements OnChanges, OnDestroy {
   wafrnFormattedContent: Array<string | WafrnMedia> = []
   seenMedia: number[] = []
 
-  readonly mediaElement = viewChild<ElementRef<HTMLElement>>('media')
+  readonly inlineMediaElement = viewChild<ElementRef<HTMLElement>>('mediaInline')
+  readonly endMediaElement = viewChild<ElementRef<HTMLElement>>('mediaEnd')
   viewer: Viewer | undefined
 
   constructor(
@@ -343,10 +344,14 @@ export class PostFragmentComponent implements OnChanges, OnDestroy {
   }
 
   ngAfterViewInit(): void {
-    const media = this.mediaElement()
-    if (!media) return
+    this.attachViewer(this.inlineMediaElement())
+    this.attachViewer(this.endMediaElement())
+  }
 
-    this.viewer = new Viewer(media.nativeElement, {
+  attachViewer(container: ElementRef<HTMLElement> | undefined) {
+    if (!container) return
+
+    this.viewer = new Viewer(container.nativeElement, {
       button: true,
       navbar: true,
       toolbar: {


### PR DESCRIPTION
Fixes #235 

Emojis were clickable as part of the images for a post. Now they're not!

## Before

![image](https://github.com/user-attachments/assets/4ad9e4af-4ddd-4a4a-99d1-ac87077f8eb2)

## After

They aren't clickable!