### PR TITLE
feat: center and margin drawer footer

### DIFF
--- a/packages/frontend/src/app/components/navigation-menu/navigation-menu.component.scss
+++ b/packages/frontend/src/app/components/navigation-menu/navigation-menu.component.scss
@@ -32,3 +32,9 @@ hr {
   margin-top: auto;
   padding-top: 1rem;
 }
+
+@media (min-width: 992px) {
+  .drawer-footer {
+    justify-content: normal;
+  }
+}

--- a/packages/frontend/src/app/components/navigation-menu/navigation-menu.component.scss
+++ b/packages/frontend/src/app/components/navigation-menu/navigation-menu.component.scss
@@ -27,6 +27,8 @@ hr {
 
 .drawer-footer {
   display: flex;
+  justify-content: center;
   gap: 0.5rem;
   margin-top: auto;
+  padding-top: 1rem;
 }


### PR DESCRIPTION
Centers and adds a top padding to the drawer footer (currently the theme/color scheme selector)

## Before

![image](https://github.com/user-attachments/assets/2a04f49a-3cdd-4470-9d44-56c371bee2e4)

## After

![Screenshot From 2025-01-05 16-33-22](https://github.com/user-attachments/assets/f79b7715-aadf-478f-bff7-312d5073f59a)
