### PR TITLE
Fix splash text again

### DIFF
--- a/packages/frontend/src/styles.scss
+++ b/packages/frontend/src/styles.scss
@@ -107,6 +107,7 @@ body {
   user-select: none;
 }
 #splash-text {
+  margin: 0;
   height: 0; // Do not shift image based on text height
   max-width: 40ch;
   text-align: center;


### PR DESCRIPTION
This ***should*** fix #240 for real this time.

The issue we were noticing was that the typography style would remove all the top margin on `p` elements which wasn't loaded at the same time as the main style sheet for whatever reason. As a result, the splash text would have a top margin for a fraction of a second in some cases.

Probably some weird cache invalidation stuff or something, I'm not sure.

## Before

Top margin would pop in for a fraction of a second...

![image](https://github.com/user-attachments/assets/ca7f5d81-6912-422a-bbc1-e8f6ad6221c3)

## After

Just remove it, easy!

![image](https://github.com/user-attachments/assets/44f2ae4f-db11-4aa9-8e77-5d3d76cbfe96)
