### PR TITLE
Increase post distance

### DIFF
--- a/packages/frontend/src/app/styles/post-card.scss
+++ b/packages/frontend/src/app/styles/post-card.scss
@@ -6,7 +6,7 @@
 // The cards
 :root .post-card {
   margin-inline: 1rem;
-  margin-bottom: 0.5rem;
+  margin-bottom: 1rem;
   padding: 1rem;
   padding-bottom: 0.75rem;
 


### PR DESCRIPTION
Spaces posts out a bit more. 0.5rem -> 1rem. This is in line with Tumblr.

## Before

![image](https://github.com/user-attachments/assets/1b9e8c75-0bcb-40e9-b5ed-b96bed883965)

## After

![image](https://github.com/user-attachments/assets/811ffc8c-451a-45f5-8c01-d6df56007220)
