### PR TITLE
Style fixes again

### DIFF
--- a/packages/frontend/src/app/components/color-scheme-switcher/color-scheme-switcher.component.html
+++ b/packages/frontend/src/app/components/color-scheme-switcher/color-scheme-switcher.component.html
@@ -13,8 +13,8 @@
   <button mat-menu-item (click)="setColorScheme('tan')">Tan</button>
   <button mat-menu-item (click)="setColorScheme('green')">Green</button>
   <button mat-menu-item (click)="setColorScheme('gold')">Gold</button>
-  <hr />
-  <button mat-menu-item>
+  <hr class="my-2" />
+  <button mat-menu-item class="pl-1">
     <mat-checkbox [checked]="centerLayoutMode" (click)="updateCenterLayout()">Center layout</mat-checkbox>
   </button>
 </mat-menu>

--- a/packages/frontend/src/app/components/color-scheme-switcher/color-scheme-switcher.component.html
+++ b/packages/frontend/src/app/components/color-scheme-switcher/color-scheme-switcher.component.html
@@ -9,10 +9,11 @@
   <fa-icon [icon]="paletteIcon"></fa-icon>
 </button>
 <mat-menu #colorSchemeMenu="matMenu">
-  <button mat-menu-item (click)="setColorScheme('default')">Default</button>
-  <button mat-menu-item (click)="setColorScheme('tan')">Tan</button>
-  <button mat-menu-item (click)="setColorScheme('green')">Green</button>
-  <button mat-menu-item (click)="setColorScheme('gold')">Gold</button>
+  @for (variant of variants; track $index) {
+    <button mat-menu-item (click)="setColorScheme(variant)" [ngClass]="{ selected: variant == colorScheme() }">
+      {{ capitalize(variant) }}
+    </button>
+  }
   <hr class="my-2" />
   <button mat-menu-item class="pl-1">
     <mat-checkbox [checked]="centerLayoutMode" (click)="updateCenterLayout()">Center layout</mat-checkbox>

--- a/packages/frontend/src/app/components/color-scheme-switcher/color-scheme-switcher.component.scss
+++ b/packages/frontend/src/app/components/color-scheme-switcher/color-scheme-switcher.component.scss
@@ -3,6 +3,10 @@
   aspect-ratio: 1 / 1;
 }
 
+.selected {
+  font-weight: bold;
+}
+
 svg {
   display: block;
 }

--- a/packages/frontend/src/app/components/color-scheme-switcher/color-scheme-switcher.component.ts
+++ b/packages/frontend/src/app/components/color-scheme-switcher/color-scheme-switcher.component.ts
@@ -1,3 +1,4 @@
+import { NgClass } from '@angular/common'
 import { Component, linkedSignal, signal } from '@angular/core'
 import { MatButtonModule } from '@angular/material/button'
 import { MatCheckboxModule } from '@angular/material/checkbox'
@@ -28,11 +29,15 @@ function capitalize(text: string) {
 
 @Component({
   selector: 'app-color-scheme-switcher',
-  imports: [MatMenuModule, MatButtonModule, MatTooltipModule, FaIconComponent, MatCheckboxModule],
+  imports: [MatMenuModule, MatButtonModule, MatTooltipModule, FaIconComponent, MatCheckboxModule, NgClass],
   templateUrl: './color-scheme-switcher.component.html',
   styleUrl: './color-scheme-switcher.component.scss'
 })
 export class ColorSchemeSwitcherComponent {
+  // Utility
+  readonly variants = colorSchemeVariants
+  readonly capitalize = capitalize
+
   // Color scheme
   colorScheme = signal<ColorScheme>('default')
   colorSchemeText = linkedSignal(() => capitalize(this.colorScheme()))

--- a/packages/frontend/src/app/components/navigation-menu/navigation-menu.component.html
+++ b/packages/frontend/src/app/components/navigation-menu/navigation-menu.component.html
@@ -58,7 +58,7 @@
     >
       <fa-icon [icon]="pencilIcon"></fa-icon>
     </button>
-    <div class="pt-7">
+    <div class="wafrn-content">
       <div *ngIf="maintenanceMode" [innerHtml]="maintenanceMessage"></div>
       <router-outlet></router-outlet>
     </div>

--- a/packages/frontend/src/assets/themes/center-column.css
+++ b/packages/frontend/src/assets/themes/center-column.css
@@ -1,6 +1,5 @@
-
-.pt-7 {
-    margin-left: auto;
-    margin-right: auto;
-    max-width: 800px;
-    }
+.wafrn-content {
+  margin-left: auto;
+  margin-right: auto;
+  max-width: 800px;
+}

--- a/packages/frontend/src/styles.scss
+++ b/packages/frontend/src/styles.scss
@@ -74,6 +74,10 @@ body {
   max-width: 800px;
 }
 
+.wafrn-content {
+  padding-top: 4rem;
+}
+
 // No JavaScript
 #no-js {
   position: fixed;


### PR DESCRIPTION
Adds the `.wafrn-content` on to the router outlet div and uses that to center it. Also updates the appearance selector a little.

## Before

![image](https://github.com/user-attachments/assets/99dc0ca5-be14-4718-a4ea-c98b58869df9)

## After

![image](https://github.com/user-attachments/assets/3c980371-ac99-4b2f-995d-6f1128996fcc)
