### PR TITLE
fix: random number was not secure enough

### DIFF
--- a/packages/frontend/src/index.html
+++ b/packages/frontend/src/index.html
@@ -97,7 +97,11 @@
         ]
         const splashTextElement = document.getElementById('splash-text')
 
-        const randomSplashText = splashTextVariants[Math.floor(Math.random() * splashTextVariants.length)]
+        // We only use the most Extremely Secure way to get a random number
+        const crypto = window.crypto || window.msCrypto
+        const randArr = new Uint32Array(1)
+        crypto.getRandomValues(randArr)
+        const randomSplashText = splashTextVariants[randArr[0] % splashTextVariants.length]
 
         splashTextElement.innerText = randomSplashText
 


### PR DESCRIPTION
Changes our Very Weak `Math.random()` call to a superior security standard.

If we didn't do this, the sun would explode.