### PR TITLE
Fixed media height

### DIFF
--- a/packages/frontend/src/app/components/wafrn-media/wafrn-media.component.scss
+++ b/packages/frontend/src/app/components/wafrn-media/wafrn-media.component.scss
@@ -102,3 +102,16 @@ video {
     bottom: unset;
   }
 }
+
+/* Limit the height AGAIN */
+/* Seriously when and why did we undo this */
+.media-content-container {
+  max-height: 80vh;
+}
+
+/* fix aspect ratio/stretch */
+.media-content-container .displayed-image {
+  width: auto;
+  height: auto;
+  aspect-ratio: auto;
+}


### PR DESCRIPTION
Make sure (AGAIN) that media does not overflow outside the viewport. For comfort, this is capped at 80vh, e.g 80% of the viewport's height.