### PR TITLE
Shorten cw button text

### DIFF
--- a/packages/frontend/src/app/components/post-fragment/post-fragment.component.html
+++ b/packages/frontend/src/app/components/post-fragment/post-fragment.component.html
@@ -13,7 +13,7 @@
     @if (showSensitiveContent) {
       Hide
     } @else {
-      Show sensitive content
+      Show
       <span class="text-xs"
         >({{ wordCount() }} word{{ wordCount() === 1 ? '' : 's' }}, {{ characterCount() }} character{{
           characterCount() === 1 ? '' : 's'


### PR DESCRIPTION
Makes it "show" instead of "show sensitive content" so we don't wrap on mobile

## Before

![image](https://github.com/user-attachments/assets/64713993-d701-4ce9-b75c-0fc2f05d2c4a)

## After

![image](https://github.com/user-attachments/assets/deb423fa-c603-4bed-858a-81e66c4a05a3)
