### PR TITLE
initial test of bsky badge

### DIFF
--- a/packages/frontend/src/app/components/blog-header/blog-header.component.html
+++ b/packages/frontend/src/app/components/blog-header/blog-header.component.html
@@ -64,10 +64,15 @@
     </div>
     <div class="min-w-0">
       <p [innerHtml]="blogDetails.name" class="m-0 text-xl font-medium line-height-3"></p>
-      <p [innerText]="blogDetails.url" class="m-0 text-sm line-height-3 blog-url"></p>
+			@if (blogDetails.isBlueskyUser) {
+		    <p [innerText]="blogDetails.url" class="m-0 text-sm line-height-3 blog-url"></p>
+				<p class="bsky-badge mt-2 mb-0 text-sm line-height-3"><fa-icon class="mr-2" [icon]="bskyIcon"></fa-icon>Bluesky</p>
+			} @else {
+		    <p [innerText]="blogDetails.url" class="m-0 text-sm line-height-3 blog-url"></p>
+			}
     </div>
   </div>
-  <div [innerHtml]="blogDetails.description" class="mt-4 post-text"></div>
+  <div [innerHtml]="blogDetails.description" class="mt-2 post-text"></div>
   @if (fediAttachment.length !== 0) {
   <hr class="my-3" />
   <div class="w-full overflow-hidden flex flex-column gap-2">

--- a/packages/frontend/src/app/components/blog-header/blog-header.component.scss
+++ b/packages/frontend/src/app/components/blog-header/blog-header.component.scss
@@ -60,3 +60,11 @@ footer {
 mat-card:has(+ app-info-card) {
   margin-bottom: 0 !important;
 }
+
+.bsky-badge {
+	width: max-content;
+	border-radius: 2em;
+	background-color: rgba(0 133 255 / 0.35);
+	padding-inline: 10px;
+	padding-block: 4px;
+}

--- a/packages/frontend/src/app/components/blog-header/blog-header.component.ts
+++ b/packages/frontend/src/app/components/blog-header/blog-header.component.ts
@@ -23,6 +23,8 @@ import { PostsService } from 'src/app/services/posts.service'
 import { AskDialogContentComponent } from '../ask-dialog-content/ask-dialog-content.component'
 import { EnvironmentService } from 'src/app/services/environment.service'
 import { InfoCardComponent } from '../info-card/info-card.component'
+import { faBluesky } from '@fortawesome/free-brands-svg-icons'
+
 
 @Component({
   selector: 'app-blog-header',
@@ -49,10 +51,12 @@ export class BlogHeaderComponent implements OnChanges, OnDestroy {
   muteUserIcon = faVolumeMute
   unmuteUserIcon = faVolumeUp
   userIcon = faUser
+  bskyIcon = faBluesky
   blockUserIcon = faUserSlash
   unblockServerIcon = faServer
   allowAsk = false
   allowRemoteAsk = false
+  isBlueskyUser = false
 
   constructor(
     private loginService: LoginService,

--- a/packages/frontend/src/app/interfaces/blogDetails.ts
+++ b/packages/frontend/src/app/interfaces/blogDetails.ts
@@ -25,4 +25,5 @@ export interface BlogDetails {
   followers: number
   publicOptions: PublicOption[]
   postCount: number
+  isBlueskyUser: boolean
 }


### PR DESCRIPTION
This introduces a "Bluesky" badge on bluesky users. This means users no longer need to guess where a user is coming from, as badge = bsky and no badge = wafrn+fedi

## Screenshots:
![Screenshot From 2025-02-23 04-56-59](https://github.com/user-attachments/assets/90e9090f-55d4-4811-9128-a5050fe2e333)
it works!
![Screenshot 2025-02-23 at 04-54-23 @cyrneko eu's blog](https://github.com/user-attachments/assets/edf04357-7550-406c-8581-9bfdd893df90)

---

Note: I got no fucken clue how to typescript or javascript really I just added shit where it seems to work :trollface: