### PR TITLE
fix blog-header avatar size; it shouldn't depend on vh

### DIFF
--- a/packages/frontend/src/app/components/blog-header/blog-header.component.scss
+++ b/packages/frontend/src/app/components/blog-header/blog-header.component.scss
@@ -14,8 +14,8 @@
 }
 
 .blog-avatar-image {
-  height: 15vh;
-  max-height: 15vh;
+  max-height: 132px;
+  height: 132px;
   aspect-ratio: 1 / 1;
   object-fit: cover;
   border-radius: var(--mat-sys-corner-small);


### PR DESCRIPTION
Whyever we did this doesn't really matter, this fixes the avatar's size in the blog-header to a set height instead of relying on the `vh` unit, which made it look all kinds of weird on smaller screens for no particular reason.