### PR TITLE
WIP: Revised editor

### DIFF
--- a/packages/frontend/src/app/components/new-editor/new-editor.component.html
+++ b/packages/frontend/src/app/components/new-editor/new-editor.component.html
@@ -87,7 +87,7 @@
 
   @if (quoteOpen && !data?.quote) {
     <mat-card class="p-2 my-4" *ngIf="!quoteLoading">
-      <mat-form-field class="w-full">
+      <mat-form-field class="w-full" appearance="outline">
         <mat-label> Paste the URL of a woot to quote it. Can be the external url or the wafrn url </mat-label>
         <input [(ngModel)]="urlPostToQuote" placeholder="Just paste the woot url" matNativeControl />
       </mat-form-field>
@@ -131,7 +131,7 @@
       <ng-container *ngFor="let media of uploadedMedias; let i = index">
         <div class="col-12 md:col-6 my-2 relative">
           <app-media-preview [media]="media"></app-media-preview>
-          <mat-form-field class="w-full">
+          <mat-form-field class="w-full" appearance="outline">
             <mat-label>Image Description</mat-label>
             <textarea
               placeholder="Description. Please FILL THIS"

--- a/packages/frontend/src/app/components/new-editor/new-editor.component.html
+++ b/packages/frontend/src/app/components/new-editor/new-editor.component.html
@@ -13,7 +13,7 @@
     "
     (click)="submitPost()"
   	matTooltip="Publishes this woot">
-		<fa-icon size="lg" [icon]="postIcon"></fa-icon><span class="post-text"> Post</span>
+		<fa-icon size="lg" [icon]="postIcon"></fa-icon><span class="post-text"><b> Post</b></span>
   </button>
   @if (data && data.post && !editing) {
     <p class="text-2xl mt-2 mb-4">{{ 'editor.inReplyTo' | translate }}</p>

--- a/packages/frontend/src/app/components/new-editor/new-editor.component.html
+++ b/packages/frontend/src/app/components/new-editor/new-editor.component.html
@@ -1,6 +1,19 @@
-<mat-dialog-content>
-  <button mat-mini-fab class="delete-btn" (mousedown)="closeEditor()">
+<mat-dialog-content style="padding:0px;">
+<!-- hardcoded padding :( -->
+  <button mat-icon-button class="delete-btn" (mousedown)="closeEditor()">
     <fa-icon size="lg" [icon]="closeIcon"></fa-icon>
+  </button>
+  <button mat-flat-button
+  	class="post-btn"
+  	(mousedown)="submitPost()"
+		[disabled]="
+      !allDescriptionsFilled() ||
+      postBeingSubmitted ||
+      (postCreatorForm.value.content === initialContent && tags.length === 0 && uploadedMedias.length === 0)
+    "
+    (click)="submitPost()"
+  	matTooltip="Publishes this woot">
+		<fa-icon size="lg" [icon]="postIcon"></fa-icon><span class="post-text"> Post</span>
   </button>
   @if (data && data.post && !editing) {
     <p class="text-2xl mt-2 mb-4">{{ 'editor.inReplyTo' | translate }}</p>
@@ -9,9 +22,10 @@
       <app-post-fragment [fragment]="data.post"></app-post-fragment>
     </div>
   }
-  <h2 class="mt-3" *ngIf="editing">You are editing your woot</h2>
+  
+  <h4 class="mt-3" *ngIf="editing">You are editing your woot</h4>
   <ng-container *ngIf="data && data.ask">
-    <h2 class="mt-3">Replying ask</h2>
+    <h4 class="mt-3">Replying ask</h4>
     <app-single-ask [ask]="data.ask"></app-single-ask>
   </ng-container>
 
@@ -53,12 +67,23 @@
     </button>
   </div>
 
-  @if (showContentWarning || contentWarning) {
-    <mat-form-field class="w-full transition-size" appearance="outline">
-      <mat-label>Content warning</mat-label>
-      <input [(ngModel)]="contentWarning" placeholder="What is sensitive about this woot?" matNativeControl />
-    </mat-form-field>
+  @if (privacy === 10) {
+    <app-info-card [type]="'caution'" addClass="mb-3">
+      Admins of both your instance, and the external instance can read these messages.
+    </app-info-card>
   }
+  @if (privacy === 3) {
+    <app-info-card type="info" addClass="mb-3">
+      This woot is set as unlisted. It opts out of search, hashtags and other features. This is not recommended for
+      anything you want discoverable.
+    </app-info-card>
+  }
+  @if (showContentWarning || contentWarning) {
+  	<mat-form-field class="w-full transition-size" appearance="outline">
+  	  <mat-label>Content warning (optional)</mat-label>
+  	  <input [(ngModel)]="contentWarning" placeholder="What is sensitive about this woot?" matNativeControl />
+  	</mat-form-field>
+	}
 
   @if (quoteOpen && !data?.quote) {
     <mat-card class="p-2 my-4" *ngIf="!quoteLoading">
@@ -79,7 +104,7 @@
   }
 
   <form [formGroup]="postCreatorForm">
-    <mat-form-field class="w-full">
+    <mat-form-field class="w-full" appearance="outline">
       <mat-label>Woot text</mat-label>
       <textarea
         id="postCreatorContent"
@@ -138,9 +163,9 @@
     <div *ngIf="!data?.quote">
       <mat-spinner *ngIf="quoteLoading" class="my-4" color="accent" diameter="24"></mat-spinner>
     </div>
-    <div *ngIf="data && data.quote" class="my-4">
+    <div *ngIf="data && data.quote">
       <p class="mb-1">QUOTING:</p>
-      <div class="quoted-post">
+      <div class="quoted-post mb-4">
         <button mat-mini-fab class="delete-btn" color="warn" (mousedown)="data ? (data.quote = undefined) : null">
           <fa-icon size="lg" [icon]="closeIcon"></fa-icon>
         </button>
@@ -151,8 +176,8 @@
       </div>
     </div>
   </section>
-  <section id="tags" class="mt-2 w-full flex-row">
-    <mat-form-field class="w-full">
+  <section id="tags" class="w-full flex-row">
+    <mat-form-field class="w-full" appearance="outline">
       <mat-label>Tags</mat-label>
       <input [(ngModel)]="tags" placeholder="Separated by commas" matNativeControl />
     </mat-form-field>
@@ -163,30 +188,20 @@
     </div>
   </section>
 
-  @if (privacy === 10) {
-    <app-info-card [type]="'caution'" addClass="mb-3">
-      Admins of both your instance, and the external instance can read these messages.
-    </app-info-card>
-  }
-  @if (privacy === 3) {
-    <app-info-card type="info" class="mb-3">
-      This woot is set as unlisted. It opts out of search, hashtags and other features. This is not recommended for
-      anything you want discoverable.
-    </app-info-card>
-  }
 
-  <button
-    mat-flat-button
-    class="w-full my-2"
-    [disabled]="
-      !allDescriptionsFilled() ||
-      postBeingSubmitted ||
-      (postCreatorForm.value.content === initialContent && tags.length === 0 && uploadedMedias.length === 0)
-    "
-    (click)="submitPost()"
-  >
-    {{ editing ? 'Save woot' : idPostToReblog ? 'Publish reply to woot' : 'Publish woot' }}
-  </button>
+
+  <!-- <button -->
+  <!--   mat-flat-button -->
+  <!--   class="w-full my-2" -->
+  <!--   [disabled]=" -->
+  <!--     !allDescriptionsFilled() || -->
+  <!--     postBeingSubmitted || -->
+  <!--     (postCreatorForm.value.content === initialContent && tags.length === 0 && uploadedMedias.length === 0) -->
+  <!--   " -->
+  <!--   (click)="submitPost()" -->
+  <!-- > -->
+  <!--   {{ editing ? 'Save woot' : idPostToReblog ? 'Publish reply to woot' : 'Publish woot' }} -->
+  <!-- </button> -->
 
   <!-- Popup Menus -->
   <mat-menu #menu="matMenu">

--- a/packages/frontend/src/app/components/new-editor/new-editor.component.scss
+++ b/packages/frontend/src/app/components/new-editor/new-editor.component.scss
@@ -56,6 +56,28 @@ app-media-preview {
   z-index: 2;
 }
 
+.delete-btn.mdc-icon-button .ng-fa-icon {
+	display: block;
+	transform: translateY(-5px);
+}
+
+.post-btn {
+	position: absolute;
+	top: 16px;
+	right: 64px;
+	z-index: 2;
+}
+
+@media screen and (max-width: 380px) {
+	.post-text {
+		display: none;
+	}
+	
+	.post-btn {
+		width: 24px;
+	}
+}
+
 .quote-container {
   position: relative;
 }
@@ -88,3 +110,9 @@ app-media-preview {
 svg {
   display: block;
 }
+
+/* Sadly this doesn't actually work, I'll have to be mildly infuriated */
+/* by random padding for the rest of my life */
+/* .mat-mdc-form-field-subscript-wrapper { */
+/* 	height: 12px; */
+/* } */

--- a/packages/frontend/src/app/components/new-editor/new-editor.component.ts
+++ b/packages/frontend/src/app/components/new-editor/new-editor.component.ts
@@ -19,7 +19,8 @@ import {
   faServer,
   faSkullCrossbones,
   faUnlock,
-  faUser
+  faUser,
+  faPaperPlane
 } from '@fortawesome/free-solid-svg-icons'
 import { EditorData } from 'src/app/interfaces/editor-data'
 import { PostHeaderComponent } from '../post/post-header/post-header.component'
@@ -124,6 +125,7 @@ export class NewEditorComponent implements OnDestroy {
   skull = faSkullCrossbones
   infoIcon = faQuestionCircle
   alertIcon = faExclamationTriangle
+  postIcon=faPaperPlane
   emojiSubscription: Subscription
   editorUpdatedSubscription: Subscription | undefined
   httpMentionPetitionSubscription: Subscription | undefined


### PR DESCRIPTION
Touchups and design changes for the new-post/woot dialogue!

> [!IMPORTANT]  
> This PR is still WIP, it shouldn't be merged until the below issues are solved, and ESPECIALLY not before we've gotten feedback from users!

With this I tried to focus on a couple issues:
- [x] Incredibly large spacing inside the dialogue
- [x] Inconsistent text input appearance;  all of them use `outline` now
- [x] User has to scroll in many scenarios to even *see* the post button; Scrolling to see the button would become worse the smaller the screen
- [ ] Odd spacing around different inputs and related elements`; WIP, I will have missed some
- [ ] Contrast would be really weird with different textbox styles _`(unsure on the new design, needs testing with high-contrast)`_
- [ ] Potentially something else I forgot...??

> :white_check_mark: = fixed

# Screenshots

![Screenshot 2025-02-24 at 18-36-52 Wafrn - the social network that respects you](https://github.com/user-attachments/assets/c557a8ab-0949-4c19-b116-5bd81fed1c9a)
![Screenshot 2025-02-24 at 18-36-40 Wafrn - the social network that respects you](https://github.com/user-attachments/assets/7d3a52cc-5880-44c2-9438-c23d4c7e6ff8)
![Screenshot 2025-02-24 at 18-36-25 Wafrn - the social network that respects you](https://github.com/user-attachments/assets/489427b2-6316-4b56-a19d-168a3ecb5c29)
![Screenshot 2025-02-24 at 18-36-17 Wafrn - the social network that respects you](https://github.com/user-attachments/assets/9c1e6b4d-e961-4229-8962-4963fc048be7)

## Small screens
![Screenshot From 2025-02-24 17-17-52](https://github.com/user-attachments/assets/24caa98f-30e5-40ca-b186-123d3a51ec63)

