### PR TITLE
disable the post-privacy options when editing [frontend]

### DIFF
--- a/packages/frontend/src/app/components/new-editor/new-editor.component.html
+++ b/packages/frontend/src/app/components/new-editor/new-editor.component.html
@@ -36,6 +36,7 @@
       aria-label="Edit privacy of woot"
       class="input-height-btn"
       [matTooltip]="getPrivacyIconName()"
+      [disabled]="editing"
     >
       <fa-icon size="lg" [icon]="getPrivacyIcon()"></fa-icon>
     </button>


### PR DESCRIPTION
## Screenshots

![image](https://github.com/user-attachments/assets/6f865071-f33a-48fb-91bd-7c48bbb0a6b3)

This should also be fixed in the backend, but having it on both front+backend is not exactly bad practice either.