### PR TITLE
Fix viewer triggering on YouTube logo

### DIFF
--- a/packages/frontend/src/app/components/post-fragment/post-fragment.component.ts
+++ b/packages/frontend/src/app/components/post-fragment/post-fragment.component.ts
@@ -370,6 +370,9 @@ export class PostFragmentComponent implements OnChanges, OnDestroy {
       },
       title: false,
       className: 'viewer',
+      filter(image: HTMLImageElement) {
+        return !image.classList.contains('no-viewer')
+      },
       toggleOnDblclick: false
     })
   }

--- a/packages/frontend/src/app/services/posts.service.ts
+++ b/packages/frontend/src/app/services/posts.service.ts
@@ -408,8 +408,9 @@ export class PostsService {
     Array.from(links).forEach((link) => {
       const youtubeMatch = link.href.matchAll(this.youtubeRegex)
       if (link.innerText === link.href && youtubeMatch) {
+        // NOTE: Since this should not be part of the image Viewer, we have to add then no-viewer class to be checked for later
         Array.from(youtubeMatch).forEach((youtubeString) => {
-          link.innerHTML = `<div class="watermark"><!-- Watermark container --><div class="watermark__inner"><!-- The watermark --><div class="watermark__body"><img alt="youtube logo" class="yt-watermark" loading="lazy" src="/assets/img/youtube_logo.png"></div></div><img class="yt-thumbnail" src="${
+          link.innerHTML = `<div class="watermark"><!-- Watermark container --><div class="watermark__inner"><!-- The watermark --><div class="watermark__body"><img alt="youtube logo" class="yt-watermark no-viewer" loading="lazy" src="/assets/img/youtube_logo.png"></div></div><img class="yt-thumbnail" src="${
             EnvironmentService.environment.externalCacheurl +
             encodeURIComponent(`https://img.youtube.com/vi/${youtubeString[6]}/hqdefault.jpg`)
           }" loading="lazy" alt="Thumbnail for video"></div>`


### PR DESCRIPTION
Fixes #280 

Adds the `no-viewer` class to the icon and uses that to filter out the image element via the Viewer.

If we ever want things to not be added to the viewer in the future we can just add the no-viewer element. If it becomes burdensome we could also invert this and have all viewer related images have the `viewer` class but that would be premature optimization at this stage.