### PR TITLE
Improve wafrn embeds

### DIFF
--- a/packages/frontend/src/app/components/link-preview/link-preview.component.html
+++ b/packages/frontend/src/app/components/link-preview/link-preview.component.html
@@ -1,16 +1,19 @@
-<a target="_blank" [href]="url">
-  @if (loading) {
-    <app-loader [text]="url"></app-loader>
-  } @else {
-    <div class="media-container">
-      <div class="media-content-container">
-        <h4>{{ title | slice: 0 : 64 }}{{ title.length > 63 ? '...' : '' }}</h4>
-        <h6>{{ description | slice: 0 : 128 }}{{ description.length > 127 ? '...' : '' }}</h6>
-        <div style="text-align: center">{{ (url | slice: 0 : 32) + (url.length > 31 ? '...' : '') }}</div>
-        <div *ngIf="img" class="w-full flex">
-          <img [src]="img" style="margin: auto" />
+@if (loading) {
+} @else {
+  <a target="_blank" [href]="url" class="embed-link">
+    <div class="media-container embed-container">
+      @if (img !== '') {
+        <div class="embed-image-container">
+          <img [src]="img" alt="{{ hostname }} embed image" class="embed-image" />
         </div>
+      }
+      <div class="embed-text">
+        <h2 class="embed-title">{{ title | slice: 0 : 64 }}{{ title.length > 63 ? '...' : '' }}</h2>
+        @if (description) {
+          <p class="embed-description">{{ description | slice: 0 : 128 }}{{ description.length > 127 ? '...' : '' }}</p>
+        }
+        <p class="embed-url">{{ (hostname | slice: 0 : 64) + (hostname.length > 63 ? '...' : '') }}</p>
       </div>
     </div>
-  }
-</a>
+  </a>
+}

--- a/packages/frontend/src/app/components/link-preview/link-preview.component.scss
+++ b/packages/frontend/src/app/components/link-preview/link-preview.component.scss
@@ -1,27 +1,65 @@
-img  {
-    max-height: 50vh;
-    max-width: 100%;
-    width: auto;
-    height: auto;
-    aspect-ratio: auto;
-
+.embed-link {
+  display: block;
+  color: var(--mat-sys-on-background);
+  text-decoration: none;
 }
 
-.media-container {
+.embed-container {
+  background: var(--mat-sys-surface-container);
+  border-radius: var(--mat-sys-corner-extra-small);
+  cursor: pointer !important;
+  border: 1px solid var(--mat-sys-outline-variant);
+  overflow: hidden;
+  display: grid;
+  grid-template-columns: auto 1fr;
+}
 
-    background: var(--mat-sys-surface-container);
-    position: relative;
-    display: grid;
-    border-radius: var(--mat-sys-corner-extra-small);
-    padding: 0.5em;	
-	cursor: pointer !important;
-    border: 1px solid var(--mat-sys-outline-variant);
-    flex-shrink: 0;
-    overflow: hidden;
-    margin-bottom: 4px;
-    &:hover .toggle-button {
-      opacity: 1;
-    }
+.embed-image-container {
+  height: 100%;
+  aspect-ratio: 1 / 1;
+  position: relative;
+}
+
+.embed-image {
+  max-width: 100%;
+  height: 100%;
+  position: absolute;
+  inset: 0;
+  object-fit: cover;
+}
+
+.embed-text {
+  padding: 0.75em 1em;
+
+  .embed-image-container + & {
+    border-left: 1px solid var(--mat-sys-outline-variant);
   }
 
-  
+  &:hover {
+    .embed-title {
+      text-decoration: underline;
+    }
+  }
+}
+
+.embed-title {
+  margin: 0;
+  font-size: 1.2em;
+  font-weight: bold;
+  line-height: 1.2;
+  margin-bottom: 0.375rem;
+}
+
+.embed-description {
+  margin: 0;
+  font-size: 0.85em;
+  line-height: 1.2;
+  margin-bottom: 0.375rem;
+}
+
+.embed-url {
+  margin: 0;
+  font-size: 0.9em;
+  line-height: 1.2;
+  color: var(--mat-sys-outline);
+}

--- a/packages/frontend/src/app/components/link-preview/link-preview.component.ts
+++ b/packages/frontend/src/app/components/link-preview/link-preview.component.ts
@@ -1,13 +1,13 @@
 import { Component, inject, Input, OnChanges, SimpleChanges } from '@angular/core'
 import { EnvironmentService } from 'src/app/services/environment.service'
 import { MediaService } from 'src/app/services/media.service'
-import { LoaderComponent } from '../loader/loader.component'
 import { MatCardModule } from '@angular/material/card'
 import { CommonModule } from '@angular/common'
+import { CloseScrollStrategy } from '@angular/cdk/overlay'
 
 @Component({
   selector: 'app-link-preview',
-  imports: [CommonModule, LoaderComponent, MatCardModule],
+  imports: [CommonModule, MatCardModule],
   templateUrl: './link-preview.component.html',
   styleUrl: './link-preview.component.scss'
 })
@@ -18,6 +18,7 @@ export class LinkPreviewComponent implements OnChanges {
 
   loading = true
   url = ''
+  hostname = ''
   title = ''
   description = ''
   img = ''
@@ -27,6 +28,7 @@ export class LinkPreviewComponent implements OnChanges {
       this.loading = true
       const linkToGet = this.link.startsWith(EnvironmentService.environment.externalCacheurl)
       this.url = linkToGet ? (new URL(this.link).searchParams.get('media') as string) : this.link
+      this.hostname = new URL(this.url).hostname
       this.mediaService.getLinkPreview(this.url).then((data) => {
         this.loading = false
         if (data.images && data.images.length) {
@@ -37,11 +39,12 @@ export class LinkPreviewComponent implements OnChanges {
             EnvironmentService.environment.externalCacheurl +
             encodeURIComponent(data.favicons[data.favicons.length - 1])
         }
+        let sitenamePrefix = ''
         if (data.siteName) {
-          this.title = data.siteName
+          sitenamePrefix = data.siteName + ' - '
         }
         if (data.title) {
-          this.title = this.title + ' - ' + data.title
+          this.title = sitenamePrefix + data.title
         }
         if (data.description) {
           this.description = data.description


### PR DESCRIPTION
Improves the look of wafrn embeds as based on Sharkey/misskey(?) embeds.

## Before

Embeds with images:

![image](https://github.com/user-attachments/assets/8bb6acf5-f7a1-41ff-9e3a-b9105b7f4389)

Embeds with favicons:

![image](https://github.com/user-attachments/assets/ab8f5900-8782-4074-a896-dda08af4bcc6)

Embeds with broken links:

![image](https://github.com/user-attachments/assets/6e0b5b28-7c35-4c56-b732-e5b8d0c1a262)

## After

Embeds with images:

![image](https://github.com/user-attachments/assets/55ce68f0-69f7-4808-bc6c-932f4bff2250)

Embeds with favicons:

![image](https://github.com/user-attachments/assets/3e2a65f1-96a1-460a-abdb-0570ca391ad6)

Embeds with broken links:

![image](https://github.com/user-attachments/assets/65be71a0-3b1e-40d7-96bf-28b72f3f1120)

## Omake

Fucked Up and Evil CSS:

![image](https://github.com/user-attachments/assets/a7718631-6dc2-45e7-b763-e07b9a128dfc)

(this allows for similar styling to the `background-image` trick but with broken image alt text displaying)
