### PR TITLE
Made avatars rounder, blog-header banner full-width, and made avatar …

### DIFF
--- a/packages/frontend/src/app/components/blog-header/blog-header.component.scss
+++ b/packages/frontend/src/app/components/blog-header/blog-header.component.scss
@@ -1,6 +1,6 @@
 .blog-header-image {
-  margin-top: -0.375rem;
-  margin-inline: -0.375rem;
+  margin-top: -1rem;
+  margin-inline: -1rem;
   background-color: var(--mat-sys-primary-fixed-dim);
   box-shadow: 0 0 5px -1px rgba(0, 0, 0, 0.1) inset, 0 0 10px 0 rgba(0, 0, 0, 0.07) inset,
     0 0 18px 0 rgba(0, 0, 0, 0.06) inset;
@@ -18,8 +18,8 @@
   height: 132px;
   aspect-ratio: 1 / 1;
   object-fit: cover;
-  border-radius: var(--mat-sys-corner-small);
-  margin-top: calc(-1 * 15vh + 2.5rem);
+  border-radius: var(--mat-sys-corner-large);
+  margin-top: -4rem;
   box-shadow: var(--mat-sys-level2);
 }
 


### PR DESCRIPTION
…position not depend on vh

this looks nicer, but also fixes the issue of the avatar and bio moving around depending on window size. It is consistently `-4rem` now.

## Screenshots

### New
![image](https://github.com/user-attachments/assets/34f60647-37e1-4c99-a1f9-b98aca87b786)

### Old
![image](https://github.com/user-attachments/assets/5f642b26-2d90-43bf-8557-3ae3344ba089)

Not really visible: Avatar doesn't move due to use of vh in positioning (that'd require a screen recording)