### PR TITLE
Add relevant styles and HTML changes for media-carousel.

### DIFF
--- a/packages/frontend/src/app/components/post-fragment/post-fragment.component.html
+++ b/packages/frontend/src/app/components/post-fragment/post-fragment.component.html
@@ -38,11 +38,15 @@
   <div *ngIf="fragment.questionPoll">
     <app-poll [poll]="fragment.questionPoll"></app-poll>
   </div>
-  <section #mediaEnd class="flex flex-column gap-3">
+	<!-- "media-carousel" class goes in this section ↓ -->
+	<!-- It matches for .media-gallery.media-carousel -->
+  <section #mediaEnd class="flex flex-column gap-3 media-gallery">
     @for (media of fragment.medias; track $index) {
       <app-wafrn-media *ngIf="!seenMedia.includes($index)" [data]="media"></app-wafrn-media>
     }
   </section>
+  <!-- another section for link previews that notably *doesn't* have -->
+  <!-- .media-gallery here would be appreciated. -->
   <div class="flex flex-wrap gap-2 tag-list" *ngIf="fragment.tags && fragment.tags.length">
     @for (tag of fragment.tags; track $index) {
       <a class="tag" [routerLink]="'/dashboard/search/' + tag.tagName"> #{{ tag.tagName }} </a>

--- a/packages/frontend/src/styles.scss
+++ b/packages/frontend/src/styles.scss
@@ -176,9 +176,45 @@ body {
   }
 }
 
-
-
 .shortened-post {
   max-height: 450px;
   overflow: hidden;
+}
+
+/* Horizontal Media Carousel. Disabled by default. */
+.media-gallery.media-carousel {
+  /* 
+     I am not accounting for a bunch of 
+     bugs with the link-preview here because
+     when we're done with this those won't be a child of .media-gallery anymore.
+  */
+  --media-height: 32rem;
+  flex-direction: row!important;
+  overflow-x: scroll;
+  gap: 12px!important;
+  app-wafrn-media {
+    box-sizing: border-box;
+    width: fit-content;
+    flex-shrink: 0;
+    box-sizing: border-box;
+    border-radius: var(--mat-sys-corner-large);
+  }
+  .media-container {
+    border-radius: var(--mat-sys-corner-large);
+    max-height: var(--media-height);
+  }
+  .media-content-container {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: var(--media-height);
+    border-radius: var(--mat-sys-corner-large);
+  }
+  .media-content-container:has(.v-video) {
+    height: fit-content;
+  }
+  .displayed-image {
+    max-height: var(--media-height);
+    border-radius: var(--mat-sys-corner-large)!important;
+  }
 }

--- a/packages/frontend/src/styles.scss
+++ b/packages/frontend/src/styles.scss
@@ -198,6 +198,7 @@ body {
     flex-shrink: 0;
     box-sizing: border-box;
     border-radius: var(--mat-sys-corner-large);
+    max-width: 95%;
   }
   .media-container {
     border-radius: var(--mat-sys-corner-large);

--- a/packages/frontend/src/styles.scss
+++ b/packages/frontend/src/styles.scss
@@ -196,7 +196,6 @@ body {
     box-sizing: border-box;
     width: fit-content;
     flex-shrink: 0;
-    box-sizing: border-box;
     border-radius: var(--mat-sys-corner-large);
     max-width: 95%;
   }


### PR DESCRIPTION
This introduces the required CSS for a media-carousel in 100% pure CSS. Well, and a single class in the HTML I guess

This makes multiple pieces of media show up horizontally instead of vertically, which saves space (some posts were REALLY LONG because of the media, even if it's just 2 or 3)

This is disabled by default, I am currently waiting on two changes for this to be the default:
- Link-previews filtered from the normal list of media in `.media-gallery`; To avoid making the link previews part of the horizontal gallery
- UI Toggle for opting in to this new change, marked as "beta" or "experimental"; Should only add `.media-carousel` to any `.media-gallery` element.

I've tried to account for cases with video and some other edgecases as well, but we'll see what has to be accounted for once this is rolled out and people are giving feedback after opting in.

@gabboman please make this opt-in at first lmfao

## Screenshots
![Screenshot 2025-04-05 at 14-56-09 Wafrn](https://github.com/user-attachments/assets/decdab47-c0b5-4d3b-a396-55cd2833f966)
![Screenshot 2025-04-05 at 14-58-34 @nova@lunar place's blog](https://github.com/user-attachments/assets/e0b39418-396d-4091-a755-b3e2e8f5576a)
