### PR TITLE
Fix gap under post text by hiding `section`s when emtpy.

### DIFF
--- a/packages/frontend/src/app/components/post-fragment/post-fragment.component.scss
+++ b/packages/frontend/src/app/components/post-fragment/post-fragment.component.scss
@@ -13,6 +13,10 @@
   display: none !important;
 }
 
+.post-content section:empty {
+  display: none !important;
+}
+
 .reacted {
   background-color: var(--mat-sys-primary);
   color: var(--mat-sys-on-primary);


### PR DESCRIPTION
## Before
![image](https://github.com/user-attachments/assets/fd112443-2b2c-4d9d-8829-99c408787f2c)

## After
![image](https://github.com/user-attachments/assets/7f5f02d0-080c-482e-af0c-621cf6414e71)
