### PR TITLE
Follower ratio refresh

### DIFF
--- a/packages/frontend/src/app/components/blog-header/blog-header.component.html
+++ b/packages/frontend/src/app/components/blog-header/blog-header.component.html
@@ -90,7 +90,7 @@
 				<span *ngIf="blogDetails.isBlueskyUser" class="badge bsky-badge">
       	  <fa-icon class="mr-2" [icon]="bskyIcon"></fa-icon>Bluesky
       	</span>
-      	<span *ngIf="blogDetails.followers / blogDetails.followed > 10" class="badge ratio-badge">
+      	<span *ngIf="blogDetails.followers / blogDetails.followed > 5" class="badge ratio-badge">
       		<fa-icon class="mr-2" [icon]="usersIcon"></fa-icon>Follower Ratio: {{ blogDetails.followers / blogDetails.followed | number }}
       	</span>
 			</div>

--- a/packages/frontend/src/app/components/blog-header/blog-header.component.html
+++ b/packages/frontend/src/app/components/blog-header/blog-header.component.html
@@ -90,8 +90,10 @@
 				<span *ngIf="blogDetails.isBlueskyUser" class="badge bsky-badge">
       	  <fa-icon class="mr-2" [icon]="bskyIcon"></fa-icon>Bluesky
       	</span>
-      	<span *ngIf="blogDetails.followers / blogDetails.followed > 5" class="badge ratio-badge">
-      		<fa-icon class="mr-2" [icon]="usersIcon"></fa-icon>Follower Ratio: {{ blogDetails.followers / blogDetails.followed | number: '1.0-0' }}
+      	<span
+      		*ngIf="blogDetails.followers / blogDetails.followed > 5"
+      		class="badge ratio-badge">
+      		<fa-icon class="mr-2" [icon]="usersIcon"></fa-icon>Follower Ratio: {{ blogDetails.followers / blogDetails.followed | number: '1.0-0' }}:1
       	</span>
 			</div>
       </div>

--- a/packages/frontend/src/app/components/blog-header/blog-header.component.html
+++ b/packages/frontend/src/app/components/blog-header/blog-header.component.html
@@ -92,7 +92,8 @@
       	</span>
       	<span
       		*ngIf="blogDetails.followers / blogDetails.followed > 5"
-      		class="badge ratio-badge">
+      		class="badge ratio-badge"
+      		matTooltip="{{ 'For every ' + (blogDetails.followers / blogDetails.followed | number: '1.0-0') + ' followers ' + blogDetails.url + ' follows 1 user.' }}">
       		<fa-icon class="mr-2" [icon]="usersIcon"></fa-icon>Follower Ratio: {{ blogDetails.followers / blogDetails.followed | number: '1.0-0' }}:1
       	</span>
 			</div>

--- a/packages/frontend/src/app/components/blog-header/blog-header.component.html
+++ b/packages/frontend/src/app/components/blog-header/blog-header.component.html
@@ -91,7 +91,7 @@
       	  <fa-icon class="mr-2" [icon]="bskyIcon"></fa-icon>Bluesky
       	</span>
       	<span *ngIf="blogDetails.followers / blogDetails.followed > 5" class="badge ratio-badge">
-      		<fa-icon class="mr-2" [icon]="usersIcon"></fa-icon>Follower Ratio: {{ blogDetails.followers / blogDetails.followed | number }}
+      		<fa-icon class="mr-2" [icon]="usersIcon"></fa-icon>Follower Ratio: {{ blogDetails.followers / blogDetails.followed | number: '1.0-0' }}
       	</span>
 			</div>
       </div>

--- a/packages/frontend/src/app/components/blog-header/blog-header.component.html
+++ b/packages/frontend/src/app/components/blog-header/blog-header.component.html
@@ -82,13 +82,19 @@
       <p [innerHtml]="blogDetails.name" class="m-0 text-xl font-medium line-height-3"></p>
       @if (blogDetails.isBlueskyUser) {
         <p [innerText]="blogDetails.url" class="m-0 text-sm line-height-3 blog-url"></p>
-        <p class="bsky-badge mt-2 mb-0 text-sm line-height-3">
-          <fa-icon class="mr-2" [icon]="bskyIcon"></fa-icon>Bluesky
-        </p>
+        
       } @else {
         <p [innerText]="blogDetails.url" class="m-0 text-sm line-height-3 blog-url"></p>
       }
-    </div>
+			<div class="flex gap-2 mt-2 mb-0 text-sm line-height-3 profile-badges">
+				<span *ngIf="blogDetails.isBlueskyUser" class="badge bsky-badge">
+      	  <fa-icon class="mr-2" [icon]="bskyIcon"></fa-icon>Bluesky
+      	</span>
+      	<span *ngIf="blogDetails.followers / blogDetails.followed > 10" class="badge ratio-badge">
+      		<fa-icon class="mr-2" [icon]="usersIcon"></fa-icon>Follower Ratio: {{ blogDetails.followers / blogDetails.followed | number }}
+      	</span>
+			</div>
+      </div>
   </div>
   <div [innerHtml]="blogDetails.description" class="mt-2 post-text"></div>
   @if (fediAttachment.length !== 0) {
@@ -121,9 +127,6 @@
     </details>
   }
   @if (!blogDetails.url.startsWith('@') || (blogDetails.followers && blogDetails.followed)) {
-    <div *ngIf="blogDetails.followers / blogDetails.followed > 10" class="mt-2">
-      <p>{{ blogDetails.followers / blogDetails.followed | number }} Followers to following ratio</p>
-    </div>
     <footer class="mt-4 py-3 flex justify-content-evenly follow-counts">
       <div class="flex flex-column justify-content-center">
         <b class="m-0 text-lg text-center">{{ formatBigNumber(blogDetails.postCount) }}</b>

--- a/packages/frontend/src/app/components/blog-header/blog-header.component.scss
+++ b/packages/frontend/src/app/components/blog-header/blog-header.component.scss
@@ -61,10 +61,22 @@ mat-card:has(+ app-info-card) {
   margin-bottom: 0 !important;
 }
 
-.bsky-badge {
+.profile-badges {
+	flex-wrap: wrap;
+}
+
+.badge {
 	width: max-content;
 	border-radius: 2em;
-	background-color: rgba(0 133 255 / 0.35);
 	padding-inline: 10px;
 	padding-block: 4px;
+	flex-shrink: 0
+}
+
+.bsky-badge {
+	background-color: rgba(0 133 255 / 0.35);
+}
+
+.ratio-badge {
+	background-color: var(--mat-sys-secondary-container);
 }

--- a/packages/frontend/src/app/components/blog-header/blog-header.component.ts
+++ b/packages/frontend/src/app/components/blog-header/blog-header.component.ts
@@ -20,6 +20,7 @@ import { BlocksService } from 'src/app/services/blocks.service'
 import { LoginService } from 'src/app/services/login.service'
 import { MessageService } from 'src/app/services/message.service'
 import { PostsService } from 'src/app/services/posts.service'
+import { MatTooltipModule } from '@angular/material/tooltip'
 
 import { AskDialogContentComponent } from '../ask-dialog-content/ask-dialog-content.component'
 import { EnvironmentService } from 'src/app/services/environment.service'
@@ -34,6 +35,7 @@ import { faBluesky } from '@fortawesome/free-brands-svg-icons'
     FontAwesomeModule,
     MatMenuModule,
     MatButtonModule,
+    MatTooltipModule,
     RouterModule,
     InfoCardComponent
   ],

--- a/packages/frontend/src/app/components/blog-header/blog-header.component.ts
+++ b/packages/frontend/src/app/components/blog-header/blog-header.component.ts
@@ -12,7 +12,8 @@ import {
   faUser,
   faUserSlash,
   faVolumeMute,
-  faVolumeUp
+  faVolumeUp,
+  faUsers
 } from '@fortawesome/free-solid-svg-icons'
 import { BlogDetails } from 'src/app/interfaces/blogDetails'
 import { BlocksService } from 'src/app/services/blocks.service'
@@ -51,6 +52,7 @@ export class BlogHeaderComponent implements OnChanges, OnDestroy {
   unmuteUserIcon = faVolumeUp
   userIcon = faUser
   bskyIcon = faBluesky
+  usersIcon = faUsers
   blockUserIcon = faUserSlash
   unblockServerIcon = faServer
   allowAsk = false


### PR DESCRIPTION
~~MARKING AS DRAFT I WANNA MAKE ANOTHER CHANGE.~~

# okie I'm done now I promise :3

Turns the "follower ratio" text into it's own badge with an icon. As a side-effect, slight refactor of badges as a whole.

Also adds a tooltip to the badge, to better explain how the label is read in case someone gets confused.

Good accounts to test:
- [`@bsky.app`](https://wafrn-git-fork-cyrneko-follower-ratio-04d5f1-gabbomans-projects.vercel.app/blog/@bsky.app)
- [`@delta@chaos.social`](https://wafrn-git-fork-cyrneko-follower-ratio-04d5f1-gabbomans-projects.vercel.app/blog/@delta@chaos.social)

(links are to the vercel preview)