### PR TITLE
Fix register hints overlapping

### DIFF
--- a/packages/frontend/src/app/pages/register/register.component.html
+++ b/packages/frontend/src/app/pages/register/register.component.html
@@ -16,7 +16,7 @@
       <input formControlName="email" type="email" matInput />
     </mat-form-field>
 
-    <mat-form-field class="w-full">
+    <mat-form-field class="w-full" subscriptSizing="dynamic">
       <mat-label>Password</mat-label>
       <input [type]="isPasswordVisible ? 'text' : 'password'" formControlName="password" matInput />
       <button mat-icon-button matSuffix type="button" (click)="togglePasswordVisibility()">
@@ -27,19 +27,19 @@
       </mat-error>
     </mat-form-field>
 
-    <mat-form-field class="w-full mb-3">
+    <mat-form-field class="w-full mb-3" subscriptSizing="dynamic">
       <mat-label>Your username</mat-label>
       <input formControlName="url" type="text" matInput />
       <mat-hint>Right now we do not allow special characters nor spaces</mat-hint>
     </mat-form-field>
 
-    <mat-form-field class="w-full mb-3">
+    <mat-form-field class="w-full mb-3" subscriptSizing="dynamic">
       <mat-label>Describe yourself</mat-label>
       <input formControlName="description" type="text" matInput />
       <mat-hint>A short description of yourself so other people can know who you are</mat-hint>
     </mat-form-field>
 
-    <mat-form-field class="w-full mb-3">
+    <mat-form-field class="w-full mb-3" subscriptSizing="dynamic">
       <mat-label>Your birth date</mat-label>
       <input
         formControlName="birthDate"
@@ -55,7 +55,7 @@
       <mat-datepicker-toggle matIconSuffix [for]="picker"></mat-datepicker-toggle>
       <mat-datepicker #picker></mat-datepicker>
     </mat-form-field>
-    <mat-form-field class="w-full mb-3">
+    <mat-form-field class="w-full mb-3" subscriptSizing="dynamic">
       <mat-label>Gender</mat-label>
       <mat-hint>This actually does not do anything at all</mat-hint>
       <mat-select>

--- a/packages/frontend/src/app/pages/register/register.component.html
+++ b/packages/frontend/src/app/pages/register/register.component.html
@@ -16,7 +16,7 @@
       <input formControlName="email" type="email" matInput />
     </mat-form-field>
 
-    <mat-form-field class="w-full" subscriptSizing="dynamic">
+    <mat-form-field class="w-full">
       <mat-label>Password</mat-label>
       <input [type]="isPasswordVisible ? 'text' : 'password'" formControlName="password" matInput />
       <button mat-icon-button matSuffix type="button" (click)="togglePasswordVisibility()">


### PR DESCRIPTION
Longer hints in register form were taking more than one line, which resulted in hints overlapping to the next field after the hint. Added a parameter to make them dynamic.

Before:
![image](https://github.com/user-attachments/assets/3f918b71-df8a-4232-a4fa-f9120db66bfe)

After:
![image](https://github.com/user-attachments/assets/f8d8d19d-f26b-4d10-814d-b587d78bcc1b)
