### PR TITLE
Clean up docker compose based install

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,46 @@
+# Backend details
+ADMINUSER=admin
+ADMINEMAIL="admin@example.com"
+# CHANGEME
+ADMINPASSWORD=example_password
+JWTSECRET=secret
+# CHANGEME: 2nd 'root' is the password
+MAINDB=root:root@db:5432
+DBNAME=wafrn
+DOMAINNAME=localhost
+PORT=9000
+SMTPHOST=smtp.example.com
+SMTPUSER=wafrn
+SMTPPORT=9003
+SMTPPASSWORD=example_password # CHANGEME
+SMTPFROM=wafrn@example.com
+REDISHOST=redis
+REDISPORT=6379
+# this makes the logs really heavy, but might be useful for debugging
+LOG_SQL_QUERIES=false
+# needs to be escaped for the sed command (\/) and yaml (\\)
+FRONTEND_PATH="\\/wafrn\\/packages\\/frontend"
+FRONTEND_LOGO="\\/assets\\/logo.png"
+FRONTEND_SHORTEN_POSTS=3
+FRONTEND_DISABLE_PWA=false
+FRONTEND_MAINTENANCE=false
+FRONTEND_API_URL="\\/api"
+FRONTEND_CACHE_URL="\\/api\\/cache?media="
+FRONTEND_MEDIA_URL="\\/api\\/uploads"
+
+# Frontend details
+# Important: Do not include the protocol (http://) here
+BACKEND_URL=localhost:9000
+FRONTEND_URL=localhost:9992
+SERVER_NAME=localhost:9992
+ADMIN_EMAIL=admin@localhost:9992
+CACHE_URL=localhost:9992
+MEDIA_URL=localhost:9992
+
+# Database
+POSTGRES_USER=root
+POSTGRES_PASSWORD=root
+POSTGRES_DB=wafrn
+
+# Let's Encrypt
+ACME_EMAIL=mail@example.com

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ testem.log
 # System Files
 .DS_Store
 Thumbs.db
+
+# Environment
+.env

--- a/README.md
+++ b/README.md
@@ -59,13 +59,17 @@ packages/
 
 ### What will you need
 
-Before trying to host your own wafrn, we advise you to please, very please, [join our matrix channel](https://matrix.to/#/!KFbQcLWJSAEcoKGxhl:matrix.org?via=matrix.org&via=t2bot.io) to get support
+Before trying to host your own wafrn, we advise you to please, very please, [join our discord channel](https://discord.gg/EXpCBpvM) to get support
+
+Next decide if you wish to install and run wafrn natively or using docker
+
+### Native setup
 
 First, you will need a Debian 12 VPS. The cheap Contabo one can do the trick with no problem. Maybe even the OVH one that costs 3 euros too. But I advise as a minimum the Contabo one.
 You also need a domain.
 You will also need a way of sending emails to the people registering. An SMTP server or a free Brevo account with SMTP enabled can do the trick.
 
-### First steps
+#### First steps
 
 First, point the domain to your Debian VPS. Once that is done, we download the installer and execute it, as root.
 The installer will install all required packages, create the user and clone the repo and configure Apache.
@@ -83,7 +87,7 @@ This script will download all requirements and will create a user in your system
 
 Follow the instructions of the script. It will leave the system ready with wafrn installed, the frontend deployed and the server ready to start. You're almost there!
 
-### Populate database
+#### Populate database
 
 Ok, we have the stuff ready. Log in as the user we just created (it has asked it during the previous script)
 
@@ -126,11 +130,57 @@ You're ready!
 
 **Remember, remove the admin password from the environment.ts in the backend package!**
 
-### Update wafrn
+#### Update wafrn
 
 To update wafrn, you just do the command `npm run full:upgrade` in the wafrn folder.
 
 This will do a pull the latest changes and keep the waffle up to date
+
+### Docker
+
+To get wafrn running under docker we have provided a shiny `docker-compose.yml` file. The steps below have been tested on an Ubuntu machine with Docker installed via the official install scripts.
+
+#### Checkout project
+
+You'll need to get the project files ready in a directory of your choice. 
+
+```sh
+git clone https://github.com/gabboman/wafrn
+cd wafrn
+```
+
+Should do the trick
+
+#### Configure environment
+
+Create your own `.env` file by using the example provided:
+
+```sh
+cp .env.example .env
+```
+
+Next you'll need to fill in all of the details of your domain. For example if you're trying to run your website under `wafrn.example.com` (and your DNS is already pointing to the computer running docker) you'll need to update the following details:
+
+```sh
+DOMAINNAME=wafrn.example.com
+BACKEND_URL=wafrn.example.com
+FRONTEND_URL=wafrn.example.com
+SERVER_NAME=wafrn.example.com
+CACHE_URL=wafrn.example.com
+MEDIA_URL=wafrn.example.com
+```
+
+Also make sure to get your SMTP settings, your `ACME_EMAIL` and anything that looks like a password in the config changed from the default.
+
+#### Run
+
+Next to run the setup just call
+
+```
+docker compose build && docker compose up
+```
+
+Once the scripts run and everything is okay you should be able to access your website at `https://wafrn.example.com`
 
 </details>
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,33 +5,33 @@ services:
       dockerfile: Dockerfile
       # these args configure private env vars for the backend and public env vars for the frontend
       args:
-        ADMINUSER: admin
-        ADMINEMAIL: "admin@example.com"
-        ADMINPASSWORD: example_password # CHANGEME
-        JWTSECRET: secret
-        MAINDB: root:root@db:5432 # CHANGEME: 2nd 'root' is the password
-        DBNAME: wafrn
-        DOMAINNAME: localhost
-        PORT: 9000
-        SMTPHOST: smtp.example.com
-        SMTPUSER: wafrn
-        SMTPPORT: 9003
-        SMTPPASSWORD: example_password # CHANGEME
-        SMTPFROM: wafrn@example.com
-        REDISHOST: redis
-        REDISPORT: 6379
-        LOG_SQL_QUERIES: false # this makes the logs really heavy, but might be useful for debugging
-        FRONTEND_PATH: "\\/wafrn\\/packages\\/frontend" # needs to be escaped for the sed command (\/) and yaml (\\)
-        ## Uncomment and change these if you want to configure the frontend environment variables
-        # FRONTEND_LOGO: "\\/assets\\/logo.png"
-        # FRONTEND_URL: "localhost:9992"
-        # FRONTEND_SHORTEN_POSTS: 3
-        # FRONTEND_DISABLE_PWA: false
-        # FRONTEND_MAINTENANCE: false
-        ## You can use a full URL in the next three if you want
-        # FRONTEND_API_URL: "\\/api"
-        # FRONTEND_CACHE_URL: "\\/api\\/cache?media="
-        # FRONTEND_MEDIA_URL: "\\/api\\/uploads"
+        ADMINUSER: ${ADMINUSER}
+        ADMINEMAIL: ${ADMINEMAIL}
+        ADMINPASSWORD: ${ADMINPASSWORD}
+        JWTSECRET: ${JWTSECRET}
+        MAINDB: ${MAINDB}
+        DBNAME: ${DBNAME}
+        DOMAINNAME: ${DOMAINNAME}
+        PORT: ${PORT}
+        SMTPHOST: ${SMTPHOST}
+        SMTPUSER: ${SMTPUSER}
+        SMTPPORT: ${SMTPPORT}
+        SMTPPASSWORD: ${SMTPPASSWORD}
+        SMTPFROM: ${SMTPFROM}
+        REDISHOST: ${REDISHOST}
+        REDISPORT: ${REDISPORT}
+        LOG_SQL_QUERIES: ${LOG_SQL_QUERIES}
+        FRONTEND_PATH: ${FRONTEND_PATH}
+        MEDIA_URL: ${MEDIA_URL}
+        CACHE_URL: ${CACHE_URL}
+        FRONTEND_LOGO: ${FRONTEND_LOGO}
+        FRONTEND_URL: ${FRONTEND_URL}
+        FRONTEND_SHORTEN_POSTS: ${FRONTEND_SHORTEN_POSTS}
+        FRONTEND_DISABLE_PWA: ${FRONTEND_DISABLE_PWA}
+        FRONTEND_MAINTENANCE: ${FRONTEND_MAINTENANCE}
+        FRONTEND_API_URL: ${FRONTEND_API_URL}
+        FRONTEND_CACHE_URL: ${FRONTEND_CACHE_URL}
+        FRONTEND_MEDIA_URL: ${FRONTEND_MEDIA_URL}
     depends_on:
       - db
       - redis
@@ -43,6 +43,13 @@ services:
     volumes:
       - ./packages/backend/uploads:/wafrn/uploads
       - ./packages/backend/cache:/wafrn/cache
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.backend.rule=Host(`${DOMAINNAME}`) && (PathPrefix(`/api`) || PathPrefix(`/fediverse`) || PathPrefix(`/contexts`) || PathPrefix(`/post`) || PathPrefix(`/blog`) || PathPrefix(`/.well-known`))"
+      - "traefik.http.routers.backend.entrypoints=websecure"
+      - "traefik.http.routers.backend.tls.certresolver=myresolver"
+      - "traefik.http.middlewares.backend.headers.accesscontrolalloworiginlist=*"
+      - "traefik.http.middlewares.backend.headers.contentSecurityPolicy=default-src 'self' 'unsafe-inline' 'unsafe-eval' ${FRONTEND_URL} ${CACHE_URL} ${MEDIA_URL}; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' ${FRONTEND_URL}; img-src 'self' ${CACHE_URL} ${MEDIA_URL}; font-src 'self' ${CACHE_URL} ${MEDIA_URL}; object-src 'none'; frame-src 'none'; frame-ancestors 'none'; upgrade-insecure-requests; block-all-mixed-content"
 
   frontend:
     build:
@@ -50,24 +57,28 @@ services:
       dockerfile: packages/frontend/Dockerfile
       # these args configure apache redirections and headers
       args:
-        BACKEND_URL: backend:9000 # Important: Do not include the protocol (http://) here
-        FRONTEND_URL: localhost:9992
-        ## Uncomment and change these if want to configure server name and admin email for apache
-        # SERVER_NAME: localhost:9992
-        # ADMIN_EMAIL: admin@localhost:9992
-        ## Uncomment and change these if you have different URLs for the cache and media server
-        # CACHE_URL: localhost:9992
-        # MEDIA_URL: localhost:9992
+        BACKEND_URL: ${BACKEND_URL}
+        FRONTEND_URL: ${FRONTEND_URL}
+        SERVER_NAME: ${SERVER_NAME}
+        ADMIN_EMAIL: ${ADMIN_EMAIL}
+        CACHE_URL: ${CACHE_URL}
+        MEDIA_URL: ${MEDIA_URL}
     ports:
       - 9992:80
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.frontend.rule=Host(`${DOMAINNAME}`) && PathPrefix(`/`)"
+      - "traefik.http.routers.frontend.priority=1"
+      - "traefik.http.routers.frontend.entrypoints=websecure"
+      - "traefik.http.routers.frontend.tls.certresolver=myresolver"
 
   db:
     image: postgres:17
     restart: always
     environment:
-      POSTGRES_USER: root
-      POSTGRES_PASSWORD: root
-      POSTGRES_DB: wafrn
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
     volumes:
       - dbpg:/var/lib/postgresql
     ports:
@@ -85,5 +96,22 @@ services:
     ports:
       - "6379:6379"
 
+  traefik:
+    image: "traefik:v3.3"
+    container_name: "traefik"
+    command:
+      - "--providers.docker=true"
+      - "--providers.docker.exposedbydefault=false"
+      - "--entrypoints.websecure.address=:443"
+      - "--certificatesresolvers.myresolver.acme.tlschallenge=true"
+      - "--certificatesresolvers.myresolver.acme.email=${ACME_EMAIL}"
+      - "--certificatesresolvers.myresolver.acme.storage=/letsencrypt/acme.json"
+    ports:
+      - "443:443"
+    volumes:
+      - letsencrypt:/letsencrypt
+      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+
 volumes:
   dbpg:
+  letsencrypt:


### PR DESCRIPTION
Changes include:

* Move out the configuration from docker-compose.yml to a `.env` file so they can be changed without disturbing the docker-compose file in git
* Add traefik to handle HTTPS termination and routing between frontend & backend (trafeik was used as it allows easy configuration via labels and won't require extra files to be added)
* Added steps to readme if anyone wants to try out

Tested some core functionalities to be working with this setup (registering users, creating posts, accessing the fedivrse). Doom is broken though yet