### PR TITLE
Fix remote list service

### DIFF
--- a/packages/backend/routes/lists.ts
+++ b/packages/backend/routes/lists.ts
@@ -22,6 +22,7 @@ export default function listRoutes(app: Application) {
             .split('\n')
             .map((elem) => elem.split(',')[0])
             .slice(1)
+            .filter((elem) => elem)
           const okUsers: string[] = []
           const localUsersUrls = lines
             .filter((elem) => elem.endsWith('@' + environment.instanceUrl))
@@ -42,7 +43,7 @@ export default function listRoutes(app: Application) {
           const notFoundUsersToFetch = notFoundUsersUrls.filter((elem) => !localUsersUrls.includes(elem))
           // try to get all users
           const userFetchPromise = await Promise.allSettled(
-            notFoundUsersToFetch.map((usr) => searchRemoteUser(`@${usr}`, petitionBy))
+            notFoundUsersToFetch.map((usr) => searchRemoteUser(usr, petitionBy))
           )
           foundUsers = await User.findAll({
             where: {


### PR DESCRIPTION
We already add the required extra `@` on line 32, so when calling the service we add an extra one on top breaking the search as it will skip the line. This change fixes this.

Also makes sure to filter out any empty lines (usually the last one) from the input, as it's just noise