### PR TITLE
Add html tags to posts

### DIFF
--- a/packages/frontend/src/app/services/posts.service.ts
+++ b/packages/frontend/src/app/services/posts.service.ts
@@ -469,9 +469,15 @@ export class PostsService {
           {
             name: 'style',
             multiple: true,
-            values: ['color', 'border', 'border-*', 'font', 'font-*', 'tab-size', 'text-*']
+            values: ['color', 'border', 'border-*', 'font', 'font-*', 'tab-size', 'text-*', 'padding', 'padding-*', 'margin', 'margin-*']
           }
-               ]
+               ],
+        hr: [{
+          name: 'style',
+          multiple: true,
+          values: ['color', 'background-color', 'height', 'width', 'text-align', 'margin', 'padding', 'margin-*', 'padding-*']
+        }
+             ]
       }
     })
     // we remove stuff like img and script tags. we only allow certain stuff.

--- a/packages/frontend/src/app/services/posts.service.ts
+++ b/packages/frontend/src/app/services/posts.service.ts
@@ -446,14 +446,32 @@ export class PostsService {
       'li',
       'marquee',
       'font',
-      'blockquote'
+      'blockquote',
+      'code',
+      'hr',
+      'ol',
+      'q',
+      'small',
+      'sub',
+      'sup',
+      'table',
+      'tr',
+      'td',
+      'th'
     ]
   ): string {
     const content = post.content
     let sanitized = sanitizeHtml(content, {
       allowedTags: tags,
       allowedAttributes: {
-        a: ['href']
+        a: ['href', 'title', 'target'],
+        span: ['title',
+          {
+            name: 'style',
+            multiple: true,
+            values: ['color', 'border', 'border-*', 'font', 'font-*', 'tab-size', 'text-*']
+          }
+               ]
       }
     })
     // we remove stuff like img and script tags. we only allow certain stuff.


### PR DESCRIPTION
Hopefully I'm doing this correctly, it's the first time I'm using github to contribute!

Anyhow: I wanted to expand the list of tags users can use to modify text when creating a post, so that there are more options to format text (colors, codetext, numbered lists were missing somehow, added the ability to insert a line to separate text sections with `<hr>,` the ability to insert tables via html. I've modified the span tag to allow style attributes but only with particular CSS properties to avoid weird stuff happening.

I refrained from adding the `<img>,` `<audio>,` and `<video>` tags with the src and title attributes because I'm unsure why they're excluded. Is that a deliberate choice? 