### PR TITLE
Update posts.service.ts - allow html tags

### DIFF
--- a/packages/frontend/src/app/services/posts.service.ts
+++ b/packages/frontend/src/app/services/posts.service.ts
@@ -457,7 +457,8 @@ export class PostsService {
       'table',
       'tr',
       'td',
-      'th'
+      'th',
+      'cite'
     ]
   ): string {
     const content = post.content
@@ -465,19 +466,27 @@ export class PostsService {
       allowedTags: tags,
       allowedAttributes: {
         a: ['href', 'title', 'target'],
-        span: ['title',
-          {
-            name: 'style',
-            multiple: true,
-            values: ['color', 'border', 'border-*', 'font', 'font-*', 'tab-size', 'text-*', 'padding', 'padding-*', 'margin', 'margin-*']
-          }
-               ],
-        hr: [{
-          name: 'style',
-          multiple: true,
-          values: ['color', 'background-color', 'height', 'width', 'text-align', 'margin', 'padding', 'margin-*', 'padding-*']
+        hr: ['style'],
+        span: ['title', 'style', 'lang'],
+        '*': ['title', 'lang']
+      },
+      allowedStyles: {
+        '*': {
+        'color': ['*'],
+        'font': ['*'],
+        'font-*': ['*'],
+        'text-*': ['*'],
+        'border': ['*'],
+        'border-*': ['*'],
+        'tab-size': ['*'],
+        'padding': ['*'],
+        'padding-*': ['*'],
+        'margin-*': ['*'],
+        'margin': ['*'],
+        'background-color': ['*'],
+        'height': ['*'],
+        'width': ['*']
         }
-             ]
       }
     })
     // we remove stuff like img and script tags. we only allow certain stuff.


### PR DESCRIPTION
Added `<cite>,` which I had forgotten. Also modified the allowable html code because there was a bug where the style attribute was not working as intended. Added allowStyles to hopefully fix this. It should allow any of the style options in that list for any tag for which the style attribute is permitted. `<style>` remains disallowed.