### PR TITLE
add lite-workspace to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ Thumbs.db
 
 # Environment
 .env
+
+# lite editor
+.lite_workspace.lua


### PR DESCRIPTION
adds a line to gitignore so it ignores my `.lite_workspace.lua` files so I don't accidentally commit them