### PR TITLE
avoid loop when logged out & viewing remote user

### DIFF
--- a/packages/frontend/src/app/pages/view-blog/view-blog.component.ts
+++ b/packages/frontend/src/app/pages/view-blog/view-blog.component.ts
@@ -167,6 +167,11 @@ export class ViewBlogComponent implements OnInit, OnDestroy {
   }
 
   async loadPosts(page: number) {
+    if (!this.userLoggedIn && this.blogDetails.url.startsWith('@')) {
+      this.loading = false;
+      this.noMorePosts = true;
+      return;
+    }
     this.loading = true
     const tmpPosts = await this.dashboardService.getBlogPage(page, this.blogUrl)
     const filteredPosts = tmpPosts.filter((post: ProcessedPost[]) => {


### PR DESCRIPTION
Small change to prevent the looping requests that occur when logged out and viewing a user's profile which belongs to a remote instance, using the logic from the html component.