### PR TITLE
add edit action, don't use % for left-side icon space

### DIFF
--- a/packages/frontend/src/app/components/post-actions/post-actions.component.html
+++ b/packages/frontend/src/app/components/post-actions/post-actions.component.html
@@ -116,7 +116,11 @@
         </span>
       </button>
     } @else {
-      <button (click)="editPost()" mat-menu-item><fa-icon class="mr-2" [icon]="editedIcon"></fa-icon>Edit woot</button>
+      <button (click)="editPost()" mat-menu-item>
+      <span class="post-actions-menu-span-content">
+        <fa-icon class="mr-2" [icon]="editedIcon"></fa-icon>Edit woot
+      </span>
+      </button>
       <button *ngIf="!postSilenced" (click)="silencePost()" mat-menu-item>
         <span class="post-actions-menu-span-content">
           <fa-icon class="mr-2" [icon]="silenceIcon"></fa-icon>Silence interactions

--- a/packages/frontend/src/app/components/post-actions/post-actions.component.scss
+++ b/packages/frontend/src/app/components/post-actions/post-actions.component.scss
@@ -4,7 +4,7 @@
 
 .post-actions-menu-span-content {
   display: grid;
-  grid-template-columns: 20% 80%;
+  grid-template-columns: 32px calc(100% - 32px);
   align-items: center;
   justify-content: start;
 }


### PR DESCRIPTION
Further fix the actions context menu, it now uses an absolute size instead of a percentage (didn't think that through) and the `Edit woot` action is now accounted for too (I've simply missed that one)