### PR TITLE
reduce layout shift when browsing posts

### DIFF
--- a/packages/frontend/src/app/app-routing.module.ts
+++ b/packages/frontend/src/app/app-routing.module.ts
@@ -1,10 +1,12 @@
 import { NgModule } from '@angular/core'
-import { PreloadAllModules, RouteReuseStrategy, RouterModule, Routes } from '@angular/router'
+import { PreloadAllModules, Router, Scroll, RouteReuseStrategy, RouterModule, Routes } from '@angular/router'
 import { NavigationMenuComponent } from './components/navigation-menu/navigation-menu.component'
 import { NavigationMenuModule } from './components/navigation-menu/navigation-menu.module'
 import { isAdminGuard } from './guards/is-admin.guard'
 import { loginRequiredGuard } from './guards/login-required.guard'
 import { CustomReuseStrategy } from './services/routing.service'
+import { ViewportScroller } from '@angular/common'
+import { filter } from 'rxjs'
 
 const routes: Routes = [
   {
@@ -115,4 +117,23 @@ const routes: Routes = [
   providers: [{ provide: RouteReuseStrategy, useClass: CustomReuseStrategy }],
   exports: [RouterModule]
 })
-export class AppRoutingModule { }
+export class AppRoutingModule {
+  constructor(router: Router, viewportScroller: ViewportScroller) {
+    // Chromium does not seem to handle scrollPositionRestoration the same
+    // way as firefox does. To mitigate this, we have enforced it manually.
+    router.events
+      .pipe(filter((e) => e instanceof Scroll))
+      .subscribe((e: Scroll) => {
+        // Position is not null only on backwards navigation
+        if (e.position !== null) {
+          setTimeout(() => {
+            viewportScroller.scrollToPosition(e.position!);
+          }, 100);
+        } else if (e.anchor) {
+          viewportScroller.scrollToAnchor(e.anchor);
+        }
+      });
+
+  }
+
+}

--- a/packages/frontend/src/app/components/link-preview/link-preview.component.html
+++ b/packages/frontend/src/app/components/link-preview/link-preview.component.html
@@ -1,10 +1,12 @@
-@if (loading) {
+@if (loading && forceTenorGif) {
 } @else {
   @if (forceTenorGif) {
     FORCE TENOR ACTIVATED
   }
 
   @if (!forceTenorGif && !forceYoutube) {
+    @let t = (loading) ? '...' : title;
+    @let d = (loading) ? '...' : description;
     <a target="_blank" [href]="url" class="embed-link">
       <div class="media-container embed-container">
         @if (img !== '') {
@@ -13,10 +15,10 @@
           </div>
         }
         <div class="embed-text">
-          <h2 class="embed-title">{{ title | slice: 0 : 64 }}{{ title.length > 63 ? '...' : '' }}</h2>
-          @if (description) {
+          <h2 class="embed-title">{{ t | slice: 0 : 64 }}{{ t.length > 63 ? '...' : '' }}</h2>
+          @if (d) {
             <p class="embed-description">
-              {{ description | slice: 0 : 128 }}{{ description.length > 127 ? '...' : '' }}
+              {{ d | slice: 0 : 128 }}{{ d.length > 127 ? '...' : '' }}
             </p>
           }
           <p class="embed-url">{{ (hostname | slice: 0 : 64) + (hostname.length > 63 ? '...' : '') }}</p>

--- a/packages/frontend/src/app/components/link-preview/link-preview.component.ts
+++ b/packages/frontend/src/app/components/link-preview/link-preview.component.ts
@@ -7,7 +7,7 @@ import { CommonModule } from '@angular/common'
   selector: 'app-link-preview',
   imports: [CommonModule, MatCardModule],
   templateUrl: './link-preview.component.html',
-  styleUrl: './link-preview.component.scss'
+  styleUrl: './link-preview.component.scss',
 })
 export class LinkPreviewComponent implements OnChanges {
   private mediaService = inject(MediaService)

--- a/packages/frontend/src/app/components/poll/poll.component.html
+++ b/packages/frontend/src/app/components/poll/poll.component.html
@@ -1,6 +1,6 @@
 <form [formGroup]="form">
-  @if (poll.multiChoice) {
-    @for (option of poll.questionPollQuestions; track $index) {
+  @if (poll().multiChoice) {
+    @for (option of poll().questionPollQuestions; track $index) {
       <div class="w-full">
         <mat-checkbox [formControlName]="option.id">{{ option.questionText }}</mat-checkbox>
         <mat-progress-bar
@@ -16,7 +16,7 @@
       class="example-radio-group"
       formControlName="singleValue"
     >
-      @for (option of poll.questionPollQuestions; track $index) {
+      @for (option of poll().questionPollQuestions; track $index) {
         <div class="w-full">
           <mat-radio-button [value]="option.id">{{ option.questionText }}</mat-radio-button>
           <mat-progress-bar

--- a/packages/frontend/src/app/components/poll/poll.component.ts
+++ b/packages/frontend/src/app/components/poll/poll.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit } from '@angular/core'
+import { Component, input, OnInit } from '@angular/core'
 import { FormControl, UntypedFormGroup, Validators } from '@angular/forms'
 import { QuestionPoll } from '../../interfaces/questionPoll'
 import { LoginService } from '../../services/login.service'
@@ -11,7 +11,7 @@ import { PostsService } from '../../services/posts.service'
   standalone: false
 })
 export class PollComponent implements OnInit {
-  @Input() poll!: QuestionPoll
+  poll = input.required<QuestionPoll>();
   total = 0
   openPoll = false
   form = new UntypedFormGroup({})
@@ -26,13 +26,13 @@ export class PollComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    this.openPoll = new Date().getTime() < this.poll.endDate.getTime()
-    this.poll.questionPollQuestions.forEach((elem) => {
+    this.openPoll = new Date().getTime() < this.poll().endDate.getTime()
+    this.poll().questionPollQuestions.forEach((elem) => {
       this.total = this.total + elem.remoteReplies
     })
-    this.alreadyVoted = this.poll?.questionPollQuestions.some((question) => question.questionPollAnswers.length > 0)
-    if (this.poll?.questionPollQuestions && this.poll.questionPollQuestions.length > 0 && this.poll.multiChoice) {
-      this.poll.questionPollQuestions.forEach((question) => {
+    this.alreadyVoted = this.poll().questionPollQuestions.some((question) => question.questionPollAnswers.length > 0)
+    if (this.poll().questionPollQuestions && this.poll().questionPollQuestions.length > 0 && this.poll().multiChoice) {
+      this.poll().questionPollQuestions.forEach((question) => {
         this.form.addControl(
           question.id.toString(),
           new FormControl(
@@ -45,8 +45,8 @@ export class PollComponent implements OnInit {
         )
       })
     }
-    if (!this.poll.multiChoice) {
-      const existingReply = this.poll.questionPollQuestions.find((reply) => reply.questionPollAnswers.length > 0)
+    if (!this.poll().multiChoice) {
+      const existingReply = this.poll().questionPollQuestions.find((reply) => reply.questionPollAnswers.length > 0)
       this.form.addControl(
         'singleValue',
         new FormControl(
@@ -63,7 +63,7 @@ export class PollComponent implements OnInit {
   async vote() {
     let votes: number[] = []
     const formValue = this.form.value
-    if (this.poll.multiChoice) {
+    if (this.poll().multiChoice) {
       Object.keys(formValue).forEach((key) => {
         if (formValue[key]) {
           votes.push(parseInt(key))
@@ -72,7 +72,7 @@ export class PollComponent implements OnInit {
     } else {
       votes.push(parseInt(formValue.singleValue))
     }
-    const voteSuccess = await this.postsService.voteInPoll(this.poll.id, votes)
+    const voteSuccess = await this.postsService.voteInPoll(this.poll().id, votes)
     if (voteSuccess) {
       this.alreadyVoted = true
     }

--- a/packages/frontend/src/app/components/post-fragment/post-fragment.component.html
+++ b/packages/frontend/src/app/components/post-fragment/post-fragment.component.html
@@ -1,13 +1,13 @@
-@if (fragment.title) {
-  <h3 [innerText]="fragment.title"></h3>
+@if (fragment().title) {
+  <h3 [innerText]="fragment().title"></h3>
 }
-@if (fragment.ask) {
-  <app-single-ask [ask]="fragment.ask"></app-single-ask>
+@if (fragment().ask) {
+  <app-single-ask [ask]="fragment().ask!"></app-single-ask>
 }
-@if (fragment.content_warning || fragment.muted_words_cw) {
+@if (fragment().content_warning || fragment().muted_words_cw) {
   <div class="content-warning-text">
-    {{ fragment.muted_words_cw }}
-    {{ fragment.content_warning }}
+    {{ fragment().muted_words_cw }}
+    {{ fragment().content_warning }}
   </div>
   <button class="toggle-cw-button" mat-raised-button color="primary" (click)="cwClick()" class="w-full my-2">
     @if (showSensitiveContent) {
@@ -24,9 +24,9 @@
 }
 <div
   class="flex flex-column gap-3 post-content"
-  [ngClass]="{ hidden: (fragment.content_warning || fragment.muted_words_cw) && !showSensitiveContent }"
+  [ngClass]="{ hidden: (fragment().content_warning || fragment().muted_words_cw) && !showSensitiveContent }"
 >
-  @for (block of wafrnFormattedContent; track $index) {
+  @for (block of wafrnFormattedContent(); track $index) {
     <div #mediaInline class="fragment-content overflow-hidden">
       <div [injectHTML]="block" class="post-text"></div>
       @if (typeof block !== 'string') {
@@ -35,15 +35,15 @@
     </div>
   }
 
-  <div *ngIf="fragment.questionPoll">
-    <app-poll [poll]="fragment.questionPoll"></app-poll>
+  <div *ngIf="fragment().questionPoll">
+    <app-poll [poll]="fragment().questionPoll!"></app-poll>
   </div>
   <section
     #mediaEnd
     [ngClass]="{ 'media-carousel': !forceOldMediaStyle && nonLinkMediaCount > 1 }"
     class="flex flex-column gap-3 media-gallery"
   >
-    @for (media of fragment.medias; track $index) {
+    @for (media of fragment().medias; track $index) {
       @if (media.mediaType != 'text/html') {
         <app-wafrn-media
           [ngClass]="{
@@ -56,18 +56,18 @@
     }
   </section>
   <section #mediaEnd class="flex flex-column gap-3">
-    @for (media of fragment.medias; track $index) {
+    @for (media of fragment().medias; track $index) {
       @if (media.mediaType == 'text/html') {
         <app-wafrn-media *ngIf="!seenMedia.includes($index)" [data]="media"></app-wafrn-media>
       }
     }
   </section>
-  <div class="flex flex-wrap gap-2 tag-list" *ngIf="fragment.tags && fragment.tags.length">
-    @for (tag of fragment.tags; track $index) {
+  <div class="flex flex-wrap gap-2 tag-list" *ngIf="fragment().tags && fragment().tags.length">
+    @for (tag of fragment().tags; track $index) {
       <a class="tag" [routerLink]="'/dashboard/search/' + tag.tagName"> #{{ tag.tagName }} </a>
     }
   </div>
-  @for (quote of fragment.quotes; track $index) {
+  @for (quote of fragment().quotes; track $index) {
     <div *ngIf="quote" class="quoted-post cursor-pointer">
       <div class="flex">
         <app-post-header class="w-full" [fragment]="quote" [simplified]="true" [disableLink]="true"></app-post-header>
@@ -119,6 +119,6 @@
         </div>
       }
     }
-    <app-emoji-react *ngIf="!(userId === '' || userId === fragment.userId)" [postId]="fragment.id"></app-emoji-react>
+    <app-emoji-react *ngIf="!(userId === '' || userId === fragment().userId)" [postId]="fragment().id"></app-emoji-react>
   </section>
 </div>

--- a/packages/frontend/src/app/components/post-fragment/post-fragment.component.scss
+++ b/packages/frontend/src/app/components/post-fragment/post-fragment.component.scss
@@ -5,10 +5,6 @@
   --mdc-protected-button-container-color: var(--mat-sys-surface-container-high);
 }
 
-.post-content {
-  content-visibility: auto;
-}
-
 .post-content.hidden {
   display: none !important;
 }

--- a/packages/frontend/src/app/components/post-fragment/post-fragment.component.spec.ts
+++ b/packages/frontend/src/app/components/post-fragment/post-fragment.component.spec.ts
@@ -67,8 +67,8 @@ describe('PostFragmentComponent', () => {
       JSON.stringify(['No medias attached and ![media-1] string'])
     )
     if (component.fragment) {
-      component.fragment.content = 'post with one media ![media-1] and a second line'
-      component.fragment.medias = [
+      component.fragment().content = 'post with one media ![media-1] and a second line'
+      component.fragment().medias = [
         {
           id: '1',
           NSFW: false,
@@ -102,7 +102,7 @@ describe('PostFragmentComponent', () => {
           ' and a second line'
         ])
       )
-      component.fragment.content = 'start ![media-1] middle ![media-2] end'
+      component.fragment().content = 'start ![media-1] middle ![media-2] end'
       expect(JSON.stringify(component.seenMedia)).toBe(JSON.stringify([0]))
       component.initializeContent()
       fixture.detectChanges()
@@ -129,7 +129,7 @@ describe('PostFragmentComponent', () => {
           ' end'
         ])
       )
-      component.fragment.content = 'start ![media-249] end'
+      component.fragment().content = 'start ![media-249] end'
       component.initializeContent()
       fixture.detectChanges()
       // acceptable compromise without more headaches. Your fault for making it like this lol

--- a/packages/frontend/src/app/components/post/post.component.ts
+++ b/packages/frontend/src/app/components/post/post.component.ts
@@ -1,11 +1,8 @@
 import {
-  AfterViewChecked,
-  AfterViewInit,
   Component,
   computed,
   EventEmitter,
   Input,
-  OnChanges,
   OnDestroy,
   OnInit,
   Output,
@@ -46,9 +43,9 @@ import { environment } from 'src/environments/environment'
   selector: 'app-post',
   templateUrl: './post.component.html',
   styleUrls: ['./post.component.scss'],
-  standalone: false
+  standalone: false,
 })
-export class PostComponent implements OnInit, OnChanges, OnDestroy {
+export class PostComponent implements OnInit, OnDestroy {
   @Input() post!: ProcessedPost[]
   showFull: boolean = false
   postCanExpand = computed(() => {
@@ -167,6 +164,8 @@ export class PostComponent implements OnInit, OnChanges, OnDestroy {
     if (localStorage.getItem('automaticalyExpandPosts') === 'true') {
       this.expandPost()
     }
+    this.changed()
+
   }
 
   isEmptyReblog() {
@@ -181,7 +180,7 @@ export class PostComponent implements OnInit, OnChanges, OnDestroy {
     )
   }
 
-  ngOnChanges() {
+  changed() {
     this.ready = true
     const notes = this.post[this.post.length - 1].notes
     this.notes = notes.toString()

--- a/packages/frontend/src/app/components/wafrn-media/wafrn-media.component.html
+++ b/packages/frontend/src/app/components/wafrn-media/wafrn-media.component.html
@@ -2,16 +2,17 @@
   <app-link-preview *ngIf="displayUrl()" [link]="displayUrl()"></app-link-preview>
 } @else {
   <div class="media-container" [ngClass]="{ 'always-show-alt': alwaysShowAlt() }">
-    <div class="media-content-container">
+    <div class="media-content-container" [style.aspect-ratio]="nsfw ? aspectRatio() : 'auto'">
       @if (
         (!extensionsToHideImgTag.includes(extension()) || mimeType() === 'UNKNOWN') && !mimeType().startsWith('video')
       ) {
+        @let forceImg = displayUrl() !== '' ? displayUrl() : 'data:image/png;base64, iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACXBIWXMAAC4jAAAuIwF4pT92AAAADUlEQVQIW2NgYGD4DwABBAEAwS2OUAAAAABJRU5ErkJggg==';
         <img
           *ngIf="!errorMode"
-          [src]="displayUrl()"
+          [src]="forceImg"
           [alt]="data().description"
-          width="{{ width() }}"
-          height="{{ height() }}"
+          [width]="width()"
+          [height]="height()"
           loading="lazy"
           (error)="handleError()"
           [ngClass]="{

--- a/packages/frontend/src/app/components/wafrn-media/wafrn-media.component.scss
+++ b/packages/frontend/src/app/components/wafrn-media/wafrn-media.component.scss
@@ -17,8 +17,6 @@
 img,
 video {
   margin-inline: auto;
-  max-width: 100%;
-  height: auto;
   transition: filter 120ms ease-out;
 }
 
@@ -87,6 +85,7 @@ video {
 }
 
 .image-cw-text {
+  width: 100%;
   background-color: #0004;
   z-index: 1;
 }
@@ -112,7 +111,7 @@ video {
 
 /* fix aspect ratio/stretch */
 .media-content-container .displayed-image {
-  width: auto;
+  width: 100%;
   height: auto;
-  aspect-ratio: auto;
+  object-fit: contain;
 }

--- a/packages/frontend/src/app/components/wafrn-media/wafrn-media.component.ts
+++ b/packages/frontend/src/app/components/wafrn-media/wafrn-media.component.ts
@@ -33,13 +33,17 @@ export class WafrnMediaComponent implements OnChanges, AfterViewInit {
     this.data().external
       ? EnvironmentService.environment.externalCacheurl + encodeURIComponent(this.data().url)
       : EnvironmentService.environment.externalCacheurl +
-        encodeURIComponent(EnvironmentService.environment.baseMediaUrl + this.data().url)
+      encodeURIComponent(EnvironmentService.environment.baseMediaUrl + this.data().url)
   )
   readonly displayUrl = computed<string>(() => this.tmpUrl())
   readonly extension = computed<string>(() => this.getExtension())
   readonly mimeType = computed<string>(() => this.getMimeType())
   readonly width = computed<number | ''>(() => this.data().width ?? '')
   readonly height = computed<number | ''>(() => this.data().height ?? '')
+  // We use this aspectRatio when the sensitive content screen is visible.
+  // Could do with some refinement as it causes slight misalignment in
+  // some cases, but it is better than not having it.
+  readonly aspectRatio = computed<number>(() => ((this.data().width ?? 1) / (this.data().height ?? 1)))
   readonly enableVideoControls = computed<boolean | ''>(() => this.mediaService.checkForceClassicVideoPlayer() ?? false)
   readonly enableAudioControls = computed<boolean | ''>(() => this.mediaService.checkForceClassicAudioPlayer() ?? false)
 

--- a/packages/frontend/src/app/components/wafrn-media/wafrn-media.module.ts
+++ b/packages/frontend/src/app/components/wafrn-media/wafrn-media.module.ts
@@ -11,4 +11,4 @@ import { LinkPreviewComponent } from '../link-preview/link-preview.component'
   imports: [CommonModule, MatCardModule, MatButtonModule, FontAwesomeModule, LinkPreviewComponent],
   exports: [WafrnMediaComponent]
 })
-export class WafrnMediaModule {}
+export class WafrnMediaModule { }

--- a/packages/frontend/src/app/directives/inject-html/inject-html.directive.ts
+++ b/packages/frontend/src/app/directives/inject-html/inject-html.directive.ts
@@ -12,5 +12,5 @@ export class InjectHTMLDirective {
     }
   }
 
-  constructor(private host: ElementRef) {}
+  constructor(private host: ElementRef) { }
 }

--- a/packages/frontend/src/app/pages/view-blog/view-blog.component.ts
+++ b/packages/frontend/src/app/pages/view-blog/view-blog.component.ts
@@ -1,22 +1,14 @@
 import { Component, OnDestroy, OnInit } from '@angular/core'
-import { MatDialogRef } from '@angular/material/dialog'
 import { Meta, Title } from '@angular/platform-browser'
 import { ActivatedRoute, NavigationEnd, Router } from '@angular/router'
 import {
   faArrowUpRightFromSquare,
-  faChevronDown,
   faClockRotateLeft,
   faHeart,
   faHeartBroken,
   faHome,
   faReply,
-  faServer,
   faTriangleExclamation,
-  faUser,
-  faUserSlash,
-  faVolumeMute,
-  faVolumeUp,
-  faExclamationTriangle
 } from '@fortawesome/free-solid-svg-icons'
 import { Subscription, filter } from 'rxjs'
 import { ProcessedPost } from 'src/app/interfaces/processed-post'
@@ -183,8 +175,8 @@ export class ViewBlogComponent implements OnInit, OnDestroy {
 
 
   reloadPosts() {
-    window.scrollTo(0, 0)
     if (this.loading) return;
+    window.scrollTo(0, 0)
     this.posts = []
     this.currentPage = 0
     this.viewedPosts = 0


### PR DESCRIPTION
Improves scroll restoration somewhat

Important for Chromium and WebKit based browsers. Firefox seems to have a very different backwards/forwards cache implementation. I panicked a lil when I did another test in chromium after merge!

The critical changes here could probably be much smaller, but it took me a very long time to work out what lines did what 😵

Changes:
- Enforces scroll restoration after a small (100ms) delay.
- Add deterministic height to image media (video is possibly still a small issue due to lack of width/height)
- Disables automatic content visibility of post content.
  - I don't think this had any side effects, but was possibly the most important change (`// content-visibility: auto;`)
- Fixes issues with incorrect placement of scrollTo(top) while browsing individual blogs.
- Moves some `@Input` directives to  `input` syntax
  - Ended up being completely unnecessary, probably functionally identical, and I would be happy to revert it upon request.
- Fills embed with placeholder content while loading.
  - Title and description = `...`
  - Previously, link-previews did not get displayed while loading.

**Noteworthy Change:**
At the moment, images display as their true pixel size until they reach a certain height. This PR changes this behaviour by setting the image width to 100% of its container. The image will still respect the max-height, but is a significant changes for small images. This ensures the browser knows the size of the \<img\> regardless of if the src is loaded or not.

This would most significantly alter non-upscaled pixel art and the like, though is similar behaviour to some other websites.