### PR TITLE
fix sensitive content warning position

### DIFF
--- a/packages/frontend/src/app/components/wafrn-media/wafrn-media.component.html
+++ b/packages/frontend/src/app/components/wafrn-media/wafrn-media.component.html
@@ -2,11 +2,11 @@
   <app-link-preview *ngIf="displayUrl()" [link]="displayUrl()"></app-link-preview>
 } @else {
   <div class="media-container" [ngClass]="{ 'always-show-alt': alwaysShowAlt() }">
-    <div class="media-content-container" [style.aspect-ratio]="nsfw ? aspectRatio() : 'auto'">
+    <div class="media-content-container" >
       @if (
         (!extensionsToHideImgTag.includes(extension()) || mimeType() === 'UNKNOWN') && !mimeType().startsWith('video')
       ) {
-        @let forceImg = displayUrl() !== '' ? displayUrl() : 'data:image/png;base64, iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACXBIWXMAAC4jAAAuIwF4pT92AAAADUlEQVQIW2NgYGD4DwABBAEAwS2OUAAAAABJRU5ErkJggg==';
+        @let forceImg = (displayUrl() !== '' && !nsfw) ? displayUrl() : 'data:image/png;base64, iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACXBIWXMAAC4jAAAuIwF4pT92AAAADUlEQVQIW2NgYGD4DwABBAEAwS2OUAAAAABJRU5ErkJggg==';
         <img
           *ngIf="!errorMode"
           [src]="forceImg"
@@ -15,9 +15,9 @@
           [height]="height()"
           loading="lazy"
           (error)="handleError()"
+          [style.aspect-ratio]="nsfw ? aspectRatio() : ''"
           [ngClass]="{
-            nsfw: nsfw,
-            'displayed-image': !nsfw
+            'displayed-image': true
           }"
         />
       }
@@ -41,7 +41,7 @@
     </div>
 
     @if (nsfw) {
-      <div class="flex flex-column justify-content-center align-items-center image-cw-text">
+      <div class="flex flex-column justify-content-center align-items-center image-cw-text" >
         <p>This media contains sensitive content</p>
         <button mat-raised-button (click)="showPicture()">Show media</button>
       </div>

--- a/packages/frontend/src/app/components/wafrn-media/wafrn-media.component.scss
+++ b/packages/frontend/src/app/components/wafrn-media/wafrn-media.component.scss
@@ -86,7 +86,8 @@ video {
 
 .image-cw-text {
   width: 100%;
-  background-color: #0004;
+  padding: 0 2rem;
+  background-color: #0c0c0c;
   z-index: 1;
 }
 


### PR DESCRIPTION
**Edit:** Need to fix hard-coded colour before merge

My previous PR changed the way images were sized, and the sensitive content filter did no long display nicely in all situations. Mainly, the button was sometimes unable to be pressed due to being offscreen.

(SFW example, image of a cat) :
<details> 
<summary> Hidden images </summary>

![image](https://github.com/user-attachments/assets/9ae50859-f849-41b5-ad63-e5c89a25d1f9)

</details>
<details> 
<summary> Displayed images </summary>

![image](https://github.com/user-attachments/assets/0e14063d-92cc-4fdb-a349-bcbf32380a61)

</details>
