### PR TITLE
less funky letterboxing and sizing for media-carousel

### DIFF
--- a/packages/frontend/src/styles.scss
+++ b/packages/frontend/src/styles.scss
@@ -206,15 +206,11 @@ body {
 
 /* Horizontal Media Carousel. Disabled by default. */
 .media-gallery.media-carousel {
-  /* 
-     I am not accounting for a bunch of 
-     bugs with the link-preview here because
-     when we're done with this those won't be a child of .media-gallery anymore.
-  */
-  --media-height: 32rem;
+  --media-height: 100%;
   flex-direction: row!important;
   overflow-x: scroll;
   gap: 12px!important;
+  align-items: center;
   app-wafrn-media {
     box-sizing: border-box;
     width: fit-content;


### PR DESCRIPTION
at the expense of being Slightly Less Fancy™ with letterboxing, make the media sizing for the horizontal media carousel make sense, **especially** on phones.

## Before
![Screenshot 2025-04-16 at 19-01-21 Wafrn](https://github.com/user-attachments/assets/1bbaca7b-f702-4606-b58a-73c652d030c6)

## After
![Screenshot 2025-04-16 at 19-00-58 Wafrn](https://github.com/user-attachments/assets/3fe2780c-1682-4632-85c6-6bf9a38a4ac4)
