### PR TITLE
increment emoji count on non-like reaction

### DIFF
--- a/packages/frontend/src/app/components/post-fragment/post-fragment.component.html
+++ b/packages/frontend/src/app/components/post-fragment/post-fragment.component.html
@@ -10,7 +10,7 @@
     {{ fragment().content_warning }}
   </div>
   <button class="toggle-cw-button" mat-raised-button color="primary" (click)="cwClick()" class="w-full my-2">
-    @if (showSensitiveContent) {
+    @if (showSensitiveContent()) {
       Hide
     } @else {
       Show
@@ -24,7 +24,7 @@
 }
 <div
   class="flex flex-column gap-3 post-content"
-  [ngClass]="{ hidden: (fragment().content_warning || fragment().muted_words_cw) && !showSensitiveContent }"
+  [ngClass]="{ hidden: (fragment().content_warning || fragment().muted_words_cw) && !showSensitiveContent() }"
 >
   @for (quote of fragment().quotes; track $index) {
     <div *ngIf="quote" class="quoted-post cursor-pointer">
@@ -78,14 +78,14 @@
     }
   </div>
   <section class="mt-3" class="flex flex-wrap gap-1 emoji-reactions">
-    @for (emoji of emojiCollection; track $index) {
+    @for (emoji of emojiCollection(); track $index) {
       @if (availableEmojiNames.includes(emoji.name) || !emoji.img) {
         <!--TODO fix this! The function gettooltipusers gets called on every event
       which slows down the app when there are too many emojis
       solution: rework the emojis part so its processed only on load with all data there
       -->
         <button
-          [disabled]="reactionLoading"
+          [disabled]="reactionLoading()"
           [ngClass]="{
             reacted: emoji.includesMe
           }"
@@ -100,7 +100,7 @@
           } @else {
             <span class="force-comic-sans"> {{ emoji.content }}</span>
           }
-          @if (emoji.users.length !== 1) {
+          @if (emoji.users.length > 0) {
             <span> {{ emoji.users.length }}</span>
           }
         </button>

--- a/packages/frontend/src/app/components/wafrn-media/wafrn-media.component.html
+++ b/packages/frontend/src/app/components/wafrn-media/wafrn-media.component.html
@@ -6,7 +6,7 @@
       @if (
         (!extensionsToHideImgTag.includes(extension()) || mimeType() === 'UNKNOWN') && !mimeType().startsWith('video')
       ) {
-        @let forceImg = (displayUrl() !== '' && !nsfw) ? displayUrl() : 'data:image/png;base64, iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACXBIWXMAAC4jAAAuIwF4pT92AAAADUlEQVQIW2NgYGD4DwABBAEAwS2OUAAAAABJRU5ErkJggg==';
+        @let forceImg = (displayUrl() && !nsfw) ? displayUrl() : 'data:image/png;base64, iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACXBIWXMAAC4jAAAuIwF4pT92AAAADUlEQVQIW2NgYGD4DwABBAEAwS2OUAAAAABJRU5ErkJggg==';
         <img
           *ngIf="!errorMode"
           [src]="forceImg"

--- a/packages/frontend/src/app/pages/search/search.module.ts
+++ b/packages/frontend/src/app/pages/search/search.module.ts
@@ -15,11 +15,13 @@ import { MatTabsModule } from '@angular/material/tabs'
 const routes: Routes = [
   {
     path: '',
-    component: SearchComponent
+    component: SearchComponent,
+    data: { reuseRoute: true, feed: true }
   },
   {
     path: ':term',
-    component: SearchComponent
+    component: SearchComponent,
+    data: { reuseRoute: true, feed: true }
   }
 ]
 
@@ -41,4 +43,4 @@ const routes: Routes = [
     MatTabsModule
   ]
 })
-export class SearchModule {}
+export class SearchModule { }


### PR DESCRIPTION
I reacted to a post with the bee emoji, but the bee didn't appear on the post. Where did it go? Is it coming to visit me?

This PR increments the count of emoji reactions without the need to refresh the post. I actually think I probably broke this with the layout shift PR, but now it's done with signals... kinda. 

Not related, but this also adds route reuse for searches.

I wasn't able to test emoji removal, I think there may be an issue with the emoji removal process on the backend side

🐝