### PR TITLE
Docker: URL mapping fixes

### DIFF
--- a/packages/frontend/Caddyfile.example
+++ b/packages/frontend/Caddyfile.example
@@ -28,6 +28,7 @@ ${{DOMAIN_NAME}} {
 
     handle {
         root * /var/www/html/frontend/
+        try_files {path} /index.html
         file_server
     }
 }

--- a/packages/frontend/src/app/components/link-preview/link-preview.component.ts
+++ b/packages/frontend/src/app/components/link-preview/link-preview.component.ts
@@ -34,7 +34,7 @@ export class LinkPreviewComponent implements OnChanges {
       }
       this.loading = true
       const linkToGet = this.link.startsWith(EnvironmentService.environment.externalCacheurl)
-      this.url = linkToGet ? (new URL(this.link).searchParams.get('media') as string) : this.link
+      this.url = linkToGet ? (new URL(this.link, EnvironmentService.environment.frontUrl).searchParams.get('media') as string) : this.link
       this.hostname = new URL(this.url).hostname
       this.mediaService.getLinkPreview(this.url).then((data) => {
         this.loading = false


### PR DESCRIPTION
Fixes two minor issues when running in a small, self-contained mode:
1. Cache URLs didn't work in case the setup URL is relative, the default in a docker setting
2. `resetPassword` url didn't work as it was a dynamic one. Also fixes 404 pages