### PR TITLE
generate anchors on posts for scroll restoration

### DIFF
--- a/packages/frontend/src/app/app-routing.module.ts
+++ b/packages/frontend/src/app/app-routing.module.ts
@@ -1,12 +1,10 @@
 import { NgModule } from '@angular/core'
-import { PreloadAllModules, Router, Scroll, RouteReuseStrategy, RouterModule, Routes } from '@angular/router'
+import { PreloadAllModules, RouteReuseStrategy, RouterModule, Routes } from '@angular/router'
 import { NavigationMenuComponent } from './components/navigation-menu/navigation-menu.component'
 import { NavigationMenuModule } from './components/navigation-menu/navigation-menu.module'
 import { isAdminGuard } from './guards/is-admin.guard'
 import { loginRequiredGuard } from './guards/login-required.guard'
 import { CustomReuseStrategy } from './services/routing.service'
-import { ViewportScroller } from '@angular/common'
-import { filter } from 'rxjs'
 
 const routes: Routes = [
   {
@@ -118,22 +116,5 @@ const routes: Routes = [
   exports: [RouterModule]
 })
 export class AppRoutingModule {
-  constructor(router: Router, viewportScroller: ViewportScroller) {
-    // Chromium does not seem to handle scrollPositionRestoration the same
-    // way as firefox does. To mitigate this, we have enforced it manually.
-    router.events
-      .pipe(filter((e) => e instanceof Scroll))
-      .subscribe((e: Scroll) => {
-        // Position is not null only on backwards navigation
-        if (e.position !== null) {
-          setTimeout(() => {
-            viewportScroller.scrollToPosition(e.position!);
-          }, 100);
-        } else if (e.anchor) {
-          viewportScroller.scrollToAnchor(e.anchor);
-        }
-      });
-
-  }
 
 }

--- a/packages/frontend/src/app/app-routing.module.ts
+++ b/packages/frontend/src/app/app-routing.module.ts
@@ -108,7 +108,7 @@ const routes: Routes = [
     RouterModule.forRoot(routes, {
       preloadingStrategy: PreloadAllModules,
       anchorScrolling: 'enabled',
-      scrollPositionRestoration: 'enabled',
+      scrollPositionRestoration: 'disabled',
     }),
     NavigationMenuModule
   ],

--- a/packages/frontend/src/app/components/bottom-reply-bar/bottom-reply-bar.component.html
+++ b/packages/frontend/src/app/components/bottom-reply-bar/bottom-reply-bar.component.html
@@ -2,7 +2,8 @@
   <div class="flex align-items-center">
     @if (notes) {
       <p class="m-0 text-sm">
-        <a [routerLink]="'/fediverse/post/' + fragment.id" class="subtle-link notes-link" mat-stroked-button
+        <a [attr.id]="anchor()" [routerLink]="'/fediverse/post/' + fragment.id" class="subtle-link notes-link" mat-stroked-button
+          (click)="scrollService.setLastPostID(anchor())"
           ><b>{{ notes }}</b> notes</a
         >
       </p>

--- a/packages/frontend/src/app/components/bottom-reply-bar/bottom-reply-bar.component.ts
+++ b/packages/frontend/src/app/components/bottom-reply-bar/bottom-reply-bar.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common'
-import { Component, Input, OnChanges, signal, SimpleChanges } from '@angular/core'
+import { Component, input, Input, OnChanges, signal, SimpleChanges } from '@angular/core'
 import { MatButtonModule } from '@angular/material/button'
 import { MatTooltipModule } from '@angular/material/tooltip'
 import { RouterModule } from '@angular/router'
@@ -32,6 +32,7 @@ import { EditorService } from 'src/app/services/editor.service'
 import { LoginService } from 'src/app/services/login.service'
 import { MessageService } from 'src/app/services/message.service'
 import { PostsService } from 'src/app/services/posts.service'
+import { ScrollService } from 'src/app/services/scroll.service'
 
 @Component({
   selector: 'app-bottom-reply-bar',
@@ -42,6 +43,7 @@ import { PostsService } from 'src/app/services/posts.service'
 export class BottomReplyBarComponent implements OnChanges {
   @Input() fragment!: ProcessedPost
   @Input() notes: string = ''
+  anchor = input<string>('');
   userLoggedIn = false
   isEmptyReblog = false
   myId = ''
@@ -76,7 +78,8 @@ export class BottomReplyBarComponent implements OnChanges {
     private editorService: EditorService,
     private deletePostService: DeletePostService,
     private messages: MessageService,
-    private editor: EditorService
+    private readonly editor: EditorService,
+    public scrollService: ScrollService
   ) {
     this.userLoggedIn = loginService.checkUserLoggedIn()
     if (this.userLoggedIn) {

--- a/packages/frontend/src/app/components/post-fragment/post-fragment.component.html
+++ b/packages/frontend/src/app/components/post-fragment/post-fragment.component.html
@@ -2,7 +2,7 @@
   <h3 [innerText]="fragment().title"></h3>
 }
 @if (fragment().ask) {
-  <app-single-ask [ask]="fragment().ask!"></app-single-ask>
+  <app-single-ask (click|keypress|keydown|keyup)="scrollService.setLastPostID(anchor())" [ask]="fragment().ask!"></app-single-ask>
 }
 @if (fragment().content_warning || fragment().muted_words_cw) {
   <div class="content-warning-text">
@@ -29,10 +29,10 @@
   @for (quote of fragment().quotes; track $index) {
     <div *ngIf="quote" class="quoted-post cursor-pointer">
       <div class="flex">
-        <app-post-header class="w-full" [fragment]="quote" [simplified]="true" [disableLink]="true"></app-post-header>
+        <app-post-header [anchor]="anchor()" class="w-full" [fragment]="quote" [simplified]="true" [disableLink]="true"></app-post-header>
       </div>
-      <div class="cursor-pointer" [routerLink]="'/fediverse/post/' + quote.id">
-        <app-post-fragment [fragment]="quote"></app-post-fragment>
+      <div (click|keypress|keydown|keyup)="scrollService.setLastPostID(anchor())" class="cursor-pointer" [routerLink]="'/fediverse/post/' + quote.id">
+        <app-post-fragment [anchor]="anchor()" [fragment]="quote"></app-post-fragment>
       </div>
     </div>
   }

--- a/packages/frontend/src/app/components/post-fragment/post-fragment.component.ts
+++ b/packages/frontend/src/app/components/post-fragment/post-fragment.component.ts
@@ -32,6 +32,7 @@ import { WafrnMedia } from '../../interfaces/wafrn-media'
 
 import Viewer from 'viewerjs'
 import { Subscription } from 'rxjs'
+import { ScrollService } from 'src/app/services/scroll.service'
 
 type EmojiReaction = {
   id: string
@@ -63,6 +64,7 @@ type EmojiReaction = {
 })
 export class PostFragmentComponent implements OnChanges, OnDestroy {
   fragment = input.required<ProcessedPost>()
+  anchor = input<string>('');
   forceExpand = output<boolean>()
   showSensitiveContent = signal<boolean>(false);
   emojiCollection = signal<EmojiReaction[]>([]);
@@ -121,7 +123,8 @@ export class PostFragmentComponent implements OnChanges, OnDestroy {
     private postService: PostsService,
     private loginService: LoginService,
     private jwtService: JwtService,
-    private messages: MessageService
+    private readonly messages: MessageService,
+    public scrollService: ScrollService,
   ) {
 
   }

--- a/packages/frontend/src/app/components/post-ribbon/post-ribbon.component.html
+++ b/packages/frontend/src/app/components/post-ribbon/post-ribbon.component.html
@@ -12,7 +12,7 @@
       <fa-icon [icon]="icon()"></fa-icon>
     </div>
     <app-avatar-small [user]="user()"></app-avatar-small>
-    <p class="m-0 min-w-0 white-space-nowrap overflow-hidden text-overflow-ellipsis"><ng-content></ng-content></p>
+    <p (click|keypress|keydown|keyup)="scrollService.setLastPostID(anchor())" class="m-0 min-w-0 white-space-nowrap overflow-hidden text-overflow-ellipsis"><ng-content></ng-content></p>
     <div class="ml-auto text-sm flex-shrink-0 ribbon-date">{{ timeAgo }}</div>
   </div>
 </ng-template>

--- a/packages/frontend/src/app/components/post-ribbon/post-ribbon.component.ts
+++ b/packages/frontend/src/app/components/post-ribbon/post-ribbon.component.ts
@@ -6,6 +6,7 @@ import { MatCardModule } from '@angular/material/card'
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome'
 import { NgClass, NgTemplateOutlet } from '@angular/common'
 import { DateTime } from 'luxon'
+import { ScrollService } from 'src/app/services/scroll.service'
 
 @Component({
   selector: 'app-post-ribbon',
@@ -17,16 +18,17 @@ export class PostRibbonComponent implements OnInit {
   readonly user = input.required<SimplifiedUser>();
   readonly icon = input.required<IconDefinition>();
   readonly time = input.required<Date>();
+  readonly anchor = input<string>("");
   readonly card = input(true);
 
   timeAgo = ''
 
-  constructor() {}
+  constructor(public scrollService: ScrollService) { }
   ngOnInit(): void {
     // TODO unhardcode
     const relative = DateTime.fromJSDate(this.time()).setLocale('en').toRelative()
     this.timeAgo = relative ? relative : 'ERROR GETING TIME'
   }
 
-  ngOnChanges(changes: SimpleChanges): void {}
+  ngOnChanges(changes: SimpleChanges): void { }
 }

--- a/packages/frontend/src/app/components/post/post-header/post-header.component.html
+++ b/packages/frontend/src/app/components/post/post-header/post-header.component.html
@@ -1,10 +1,11 @@
 <div class="flex justify-content-between mb-3">
   <div class="flex flex-column gap-2 min-w-0">
     <div class="flex gap-2 min-w-0">
-      <div class="flex gap-2 mr-auto min-w-0">
+      <div [attr.id]="anchor()" class="flex gap-2 mr-auto min-w-0">
         <app-avatar-small [user]="fragment.user"></app-avatar-small>
         <a
           class="flex flex-column min-w-0 user-link"
+          (click)="scrollService.setLastPostID(anchor())"
           [routerLink]="!disableLink() ? '/blog/' + fragment.user.url : null"
         >
           <span class="no-underline user-name"
@@ -17,7 +18,7 @@
     </div>
     <div *ngIf="!simplified()" class="flex align-items-center date-line">
       <span class="text-sm" matTooltip="{{ fragment.createdAt | date: 'short' }}">
-        <a [routerLink]="'/fediverse/post/' + fragment.id" style="color: var(--mat-sys-outline)">{{ this.timeAgo }}</a>
+        <a (click)="scrollService.setLastPostID(anchor())" [routerLink]="'/fediverse/post/' + fragment.id" style="color: var(--mat-sys-outline)">{{ this.timeAgo }}</a>
       </span>
       <span *ngIf="edited" matTooltip="Edited {{ fragment.updatedAt | date: 'short' }}" class="text-xs">
         <fa-icon [icon]="editedIcon"></fa-icon>

--- a/packages/frontend/src/app/components/post/post-header/post-header.component.ts
+++ b/packages/frontend/src/app/components/post/post-header/post-header.component.ts
@@ -29,6 +29,7 @@ import {
 } from '@fortawesome/free-solid-svg-icons'
 import { MatButtonModule } from '@angular/material/button'
 import { DateTime } from 'luxon'
+import { ScrollService } from 'src/app/services/scroll.service'
 
 @Component({
   selector: 'app-post-header',
@@ -47,6 +48,7 @@ import { DateTime } from 'luxon'
 })
 export class PostHeaderComponent implements OnChanges {
   @Input() fragment!: ProcessedPost
+  anchor = input<string>('');
   readonly simplified = input<boolean>(true);
   readonly disableLink = input<boolean>(false);
   readonly headerText = input<string>('');
@@ -84,10 +86,11 @@ export class PostHeaderComponent implements OnChanges {
   constructor(
     public postService: PostsService,
     private messages: MessageService,
-    private loginService: LoginService
+    readonly loginService: LoginService,
+    public scrollService: ScrollService,
   ) {
     // its an array
-    ;(this.privacyOptions[10] = { level: 10, name: 'Direct Message', icon: faEnvelope }),
+    ; (this.privacyOptions[10] = { level: 10, name: 'Direct Message', icon: faEnvelope }),
       (this.userLoggedIn = loginService.checkUserLoggedIn())
   }
   ngOnChanges(changes: SimpleChanges): void {

--- a/packages/frontend/src/app/components/post/post.component.html
+++ b/packages/frontend/src/app/components/post/post.component.html
@@ -9,6 +9,7 @@
       [icon]="headerText === 'replied' ? replyIcon : reblogIcon"
       [card]="false"
       [time]="originalPostContent[this.originalPostContent.length - 1].createdAt"
+      [anchor]="this.anchorBase + this.finalPost.id"
     >
       <a
         class="user-link user-name"
@@ -46,8 +47,8 @@
         "
         id="fragment"
       >
-        <app-post-header class="w-full" [fragment]="content" [simplified]="false"></app-post-header>
-        <app-post-fragment (forceExpand)="expandPost()" [fragment]="content"></app-post-fragment>
+        <app-post-header [anchor]="this.anchorBase + this.finalPost.id" class="w-full" [fragment]="content" [simplified]="false"></app-post-header>
+        <app-post-fragment [anchor]="this.anchorBase + this.finalPost.id" (forceExpand)="expandPost()" [fragment]="content"></app-post-fragment>
       </div>
     }
   </div>
@@ -77,10 +78,10 @@
       >
         <hr />
         <app-post-header class="w-full" [fragment]="content" [simplified]="false"></app-post-header>
-        <app-post-fragment [fragment]="content"></app-post-fragment>
+        <app-post-fragment (click|keypress|keydown|keyup)="scrollService.setLastPostID(this.anchorBase + this.finalPost.id)" [anchor]="this.anchorBase + this.finalPost.id" [fragment]="content"></app-post-fragment>
       </div>
     }
   }
 
-  <app-bottom-reply-bar [fragment]="finalPost" [notes]="notes"></app-bottom-reply-bar>
+  <app-bottom-reply-bar [anchor]="this.anchorBase + this.finalPost.id" [fragment]="finalPost" [notes]="notes"></app-bottom-reply-bar>
 </mat-card>

--- a/packages/frontend/src/app/components/post/post.component.ts
+++ b/packages/frontend/src/app/components/post/post.component.ts
@@ -1,12 +1,8 @@
 import { Component, computed, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output, signal } from '@angular/core'
 import { ProcessedPost } from 'src/app/interfaces/processed-post'
-import { EditorService } from 'src/app/services/editor.service'
 import { LoginService } from 'src/app/services/login.service'
 import { PostsService } from 'src/app/services/posts.service'
 
-import { DeletePostService } from 'src/app/services/delete-post.service'
-import { Action } from 'src/app/interfaces/editor-launcher-data'
-import { MessageService } from 'src/app/services/message.service'
 import {
   faArrowUpRightFromSquare,
   faChevronDown,
@@ -29,6 +25,7 @@ import {
 import { EnvironmentService } from 'src/app/services/environment.service'
 import { SimplifiedUser } from 'src/app/interfaces/simplified-user'
 import { environment } from 'src/environments/environment'
+import { ScrollService } from 'src/app/services/scroll.service'
 
 @Component({
   selector: 'app-post',
@@ -37,7 +34,7 @@ import { environment } from 'src/environments/environment'
   standalone: false
 })
 export class PostComponent implements OnInit, OnDestroy, OnChanges {
-  @Input() post!: ProcessedPost[]
+  @Input() post!: ProcessedPost[];
   showFull: boolean = false
   postCanExpand = computed(() => {
     let textLength = 0
@@ -70,6 +67,7 @@ export class PostComponent implements OnInit, OnDestroy, OnChanges {
   // 0 no display at all 1 display like 2 display dislike
   showLikeFinalPost: number = 0
   finalPost!: ProcessedPost
+  anchorBase: string = '';
 
   // icons
   shareIcon = faShareNodes
@@ -107,7 +105,8 @@ export class PostComponent implements OnInit, OnDestroy, OnChanges {
 
   constructor(
     public postService: PostsService,
-    private loginService: LoginService
+    private readonly loginService: LoginService,
+    public scrollService: ScrollService
   ) {
     this.userLoggedIn = loginService.checkUserLoggedIn()
     if (this.userLoggedIn) {
@@ -137,6 +136,7 @@ export class PostComponent implements OnInit, OnDestroy, OnChanges {
   }
 
   ngOnInit(): void {
+    this.anchorBase = this.scrollService.getNext().toString() + "-id-";
     this.followedUsers = this.postService.followedUserIds
     this.notYetAcceptedFollows = this.postService.notYetAcceptedFollowedUsersIds
     this.originalPostContent = this.post

--- a/packages/frontend/src/app/components/wafrn-media/wafrn-media.component.html
+++ b/packages/frontend/src/app/components/wafrn-media/wafrn-media.component.html
@@ -8,13 +8,11 @@
       ) {
         @let forceImg = (displayUrl() && !nsfw) ? displayUrl() : 'data:image/png;base64, iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACXBIWXMAAC4jAAAuIwF4pT92AAAADUlEQVQIW2NgYGD4DwABBAEAwS2OUAAAAABJRU5ErkJggg==';
         <img
-          *ngIf="!errorMode"
           [src]="forceImg"
           [alt]="data().description"
           [width]="width()"
           [height]="height()"
           loading="lazy"
-          (error)="handleError()"
           [style.aspect-ratio]="nsfw ? aspectRatio() : ''"
           [ngClass]="{
             'displayed-image': true

--- a/packages/frontend/src/app/components/wafrn-media/wafrn-media.component.scss
+++ b/packages/frontend/src/app/components/wafrn-media/wafrn-media.component.scss
@@ -111,8 +111,10 @@ video {
 }
 
 /* fix aspect ratio/stretch */
-.media-content-container .displayed-image {
+.media-content-container {
+  .displayed-image {
   width: 100%;
   height: auto;
   object-fit: contain;
+}
 }

--- a/packages/frontend/src/app/pages/dashboard/dashboard.component.ts
+++ b/packages/frontend/src/app/pages/dashboard/dashboard.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnDestroy, OnInit } from '@angular/core'
-import { NavigationEnd, NavigationSkipped, Router } from '@angular/router'
+import { NavigationEnd, NavigationSkipped, NavigationStart, Router } from '@angular/router'
 import { ProcessedPost } from 'src/app/interfaces/processed-post'
 import { DashboardService } from 'src/app/services/dashboard.service'
 import { JwtService } from 'src/app/services/jwt.service'
@@ -104,7 +104,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
       })
 
     this.navigationEnd = this.router.events
-      .pipe(filter((event) => event instanceof NavigationEnd))
+      .pipe(filter((event) => event instanceof NavigationStart))
       .subscribe(() => {
         this.scrollService.setScrollContext(ScrollContext.Dashboard);
         let anchor = this.scrollService.getLastPostID();

--- a/packages/frontend/src/app/pages/dashboard/dashboard.component.ts
+++ b/packages/frontend/src/app/pages/dashboard/dashboard.component.ts
@@ -107,12 +107,16 @@ export class DashboardComponent implements OnInit, OnDestroy {
       .pipe(filter((event) => event instanceof NavigationEnd))
       .subscribe(() => {
         this.scrollService.setScrollContext(ScrollContext.Dashboard);
-        setTimeout(() => {
-          let anchor = this.scrollService.getLastPostID();
-          if (anchor !== '') {
+        let anchor = this.scrollService.getLastPostID();
+        if (anchor !== '') {
+          this.viewportScroller.scrollToAnchor(anchor);
+          setTimeout(() => {
             this.viewportScroller.scrollToAnchor(anchor);
-          }
-        }, 150);
+          }, 100);
+          setTimeout(() => {
+            this.viewportScroller.scrollToAnchor(anchor);
+          }, 500);
+        }
       });
 
     this.updateFollowersSubscription = this.postService.updateFollowers.subscribe(() => {

--- a/packages/frontend/src/app/pages/dashboard/dashboard.component.ts
+++ b/packages/frontend/src/app/pages/dashboard/dashboard.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnDestroy, OnInit } from '@angular/core'
-import { NavigationSkipped, Router } from '@angular/router'
+import { NavigationEnd, NavigationSkipped, Router } from '@angular/router'
 import { ProcessedPost } from 'src/app/interfaces/processed-post'
 import { DashboardService } from 'src/app/services/dashboard.service'
 import { JwtService } from 'src/app/services/jwt.service'
@@ -10,6 +10,8 @@ import { MessageService } from 'src/app/services/message.service'
 import { faArrowsRotate } from '@fortawesome/free-solid-svg-icons'
 import { Subscription } from 'rxjs'
 import { filter } from 'rxjs/operators';
+import { ScrollContext, ScrollService } from 'src/app/services/scroll.service'
+import { ViewportScroller } from '@angular/common'
 
 @Component({
   selector: 'app-dashboard',
@@ -30,6 +32,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
   reloadIcon = faArrowsRotate
   updateFollowersSubscription?: Subscription
   navigationSubscription!: Subscription
+  navigationEnd!: Subscription
   scroll = 0
 
   constructor(
@@ -41,6 +44,8 @@ export class DashboardComponent implements OnInit, OnDestroy {
     private titleService: Title,
     private metaTagService: Meta,
     private themeService: ThemeService,
+    private readonly scrollService: ScrollService,
+    private readonly viewportScroller: ViewportScroller
   ) {
     this.titleService.setTitle('Wafrn - the social network that respects you')
     this.metaTagService.addTags([
@@ -53,24 +58,12 @@ export class DashboardComponent implements OnInit, OnDestroy {
         content: 'Explore the posts in wafrn and if it looks cool join us!'
       }
     ])
-
-    // If the user clicks on the explore button while already on the page,
-    // reload posts.
-    this.navigationSubscription = this.router.events
-      .pipe(filter((event) => event instanceof NavigationSkipped))
-      .subscribe(() => {
-        if (window.scrollY > 0) {
-          // This subscription fires twice and scrollPositionRestoration is
-          // not exactly helping here!
-          // window.scrollTo(0, 0)
-          return;
-        }
-        this.reloadPosts()
-      })
   }
+
   ngOnDestroy(): void {
     this.navigationSubscription.unsubscribe()
     this.updateFollowersSubscription?.unsubscribe()
+    this.navigationEnd.unsubscribe()
   }
 
   ngOnInit(): void {
@@ -95,6 +88,32 @@ export class DashboardComponent implements OnInit, OnDestroy {
       this.level = 50
       this.title = 'My bookmarked posts'
     }
+
+    this.scrollService.setScrollContext(ScrollContext.Dashboard);
+
+    // If the user clicks on the explore button while already on the page,
+    // reload posts.
+    this.navigationSubscription = this.router.events
+      .pipe(filter((event) => event instanceof NavigationSkipped))
+      .subscribe(() => {
+        if (window.scrollY > 0) {
+          this.viewportScroller.scrollToPosition([0, 0]);
+          return;
+        }
+        this.reloadPosts()
+      })
+
+    this.navigationEnd = this.router.events
+      .pipe(filter((event) => event instanceof NavigationEnd))
+      .subscribe(() => {
+        this.scrollService.setScrollContext(ScrollContext.Dashboard);
+        setTimeout(() => {
+          let anchor = this.scrollService.getLastPostID();
+          if (anchor !== '') {
+            this.viewportScroller.scrollToAnchor(anchor);
+          }
+        }, 150);
+      });
 
     this.updateFollowersSubscription = this.postService.updateFollowers.subscribe(() => {
       if (this.postService.followedUserIds.length <= 1 && this.level === 1 && false) {
@@ -127,7 +146,6 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
 
   reloadPosts() {
-    window.scrollTo(0, 0)
     // Perhaps not a perfect solution, but without this guard currentPage and
     // startScroll may unexpectedly increase, leading to the dashboard
     // displaying posts that do not start from date.now

--- a/packages/frontend/src/app/pages/view-blog/view-blog.component.ts
+++ b/packages/frontend/src/app/pages/view-blog/view-blog.component.ts
@@ -98,12 +98,16 @@ export class ViewBlogComponent implements OnInit, OnDestroy {
           return;
         }
         this.scrollService.setScrollContext(ScrollContext.Blog);
-        setTimeout(() => {
-          let anchor = this.scrollService.getLastPostID();
-          if (anchor !== '') {
+        let anchor = this.scrollService.getLastPostID();
+        if (anchor !== '') {
+          this.viewportScroller.scrollToAnchor(anchor);
+          setTimeout(() => {
             this.viewportScroller.scrollToAnchor(anchor);
-          }
-        }, 100);
+          }, 100);
+          setTimeout(() => {
+            this.viewportScroller.scrollToAnchor(anchor);
+          }, 300);
+        }
         this.blogUrl = ''
         this.avatarUrl = ''
         this.configureUser(true)

--- a/packages/frontend/src/app/pages/view-blog/view-blog.component.ts
+++ b/packages/frontend/src/app/pages/view-blog/view-blog.component.ts
@@ -21,6 +21,8 @@ import { MatDialog } from '@angular/material/dialog'
 import { AcceptThemeComponent } from 'src/app/components/accept-theme/accept-theme.component'
 import { BlogDetails } from 'src/app/interfaces/blogDetails'
 import { EnvironmentService } from 'src/app/services/environment.service'
+import { ScrollContext, ScrollService } from 'src/app/services/scroll.service'
+import { ViewportScroller } from '@angular/common'
 @Component({
   selector: 'app-view-blog',
   templateUrl: './view-blog.component.html',
@@ -63,7 +65,9 @@ export class ViewBlogComponent implements OnInit, OnDestroy {
     private metaTagService: Meta,
     private themeService: ThemeService,
     public blockService: BlocksService,
-    private dialog: MatDialog
+    private readonly dialog: MatDialog,
+    private readonly scrollService: ScrollService,
+    private readonly viewportScroller: ViewportScroller
   ) {
     this.userLoggedIn = loginService.checkUserLoggedIn()
 
@@ -76,6 +80,7 @@ export class ViewBlogComponent implements OnInit, OnDestroy {
   }
 
   async ngOnInit() {
+    this.scrollService.setScrollContext(ScrollContext.Blog);
     this.navigationSubscription = this.router.events
       .pipe(filter((event) => event instanceof NavigationEnd))
       .subscribe((e) => {
@@ -92,6 +97,13 @@ export class ViewBlogComponent implements OnInit, OnDestroy {
           this.handleTheme()
           return;
         }
+        this.scrollService.setScrollContext(ScrollContext.Blog);
+        setTimeout(() => {
+          let anchor = this.scrollService.getLastPostID();
+          if (anchor !== '') {
+            this.viewportScroller.scrollToAnchor(anchor);
+          }
+        }, 100);
         this.blogUrl = ''
         this.avatarUrl = ''
         this.configureUser(true)
@@ -180,7 +192,6 @@ export class ViewBlogComponent implements OnInit, OnDestroy {
 
   reloadPosts() {
     if (this.loading) return;
-    window.scrollTo(0, 0)
     this.posts = []
     this.currentPage = 0
     this.viewedPosts = 0

--- a/packages/frontend/src/app/services/scroll.service.ts
+++ b/packages/frontend/src/app/services/scroll.service.ts
@@ -1,0 +1,38 @@
+import { Injectable } from "@angular/core";
+
+export enum ScrollContext {
+  Inactive,
+  Dashboard,
+  Blog,
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ScrollService {
+  context = ScrollContext.Inactive;
+  unique: number = 0;
+
+  targets = new Map<ScrollContext, string>();
+  targetID: string = '';
+
+  public getNext() {
+    return this.unique++;
+  }
+
+  public setScrollContext(context: ScrollContext) {
+    this.context = context;
+  }
+
+  public setLastPostID(id: string) {
+    this.targets.set(this.context, id);
+    this.targetID = id;
+  }
+
+  public getLastPostID(): string {
+    if (this.targets.has(this.context)) {
+      return this.targets.get(this.context)!;
+    }
+    return '';
+  }
+}


### PR DESCRIPTION
This PR introduces `ScrollService` which tracks the last post selected by the user. There are three contexts that may be active; dashboard, blog and inactive. These three contexts are activated based on where the user is navigating. This means that if a user clicks on a post on the dashboard, the ID will be tracked specifically for dashboard routes, independent from when viewing a blog. IDs are also all unique, avoiding issues with duplicate posts.

Upon route reuse, the dashboard and blog will scroll the user to the last ID recorded for their respective context after a small delay. This does not alter the history or URL in any way

I think it seems a little manual at the moment, so I'll likely return to this concept if I can clean things up, but I'm happy to see the scroll restoration return to exact posts!!

With any luck, resolves #380