### PR TITLE
Settings tabs.

### DIFF
--- a/packages/frontend/src/app/pages/profile/edit-profile/edit-profile.component.html
+++ b/packages/frontend/src/app/pages/profile/edit-profile/edit-profile.component.html
@@ -1,93 +1,156 @@
-<mat-card class="p-3 mb-6 lg:mx-4 wafrn-container">
+<mat-card class="p-3 mb-6 lg:mx-4 wafrn-container" style="transition: 1s;">
+  <mat-tab-group mat-stretch-tabs="false" mat-align-tabs="start">
   <form [hidden]="loading" [formGroup]="editProfileForm" (ngSubmit)="onSubmit()">
-    <div class="pt-2 px-3 border-round-md mb-4" style="border: 1px solid var(--mat-sys-outline-variant)">
-      <label for="avatar" class="block font-medium mb-2">Choose another avatar</label>
-      <input formControlName="avatar" id="avatar" type="file" accept="image/jpeg,image/png,image/webp,image/gif"
-        (change)="imgSelected($event)" class="w-full mb-3" />
-    </div>
-    <div class="pt-2 px-3 border-round-md mb-4" style="border: 1px solid var(--mat-sys-outline-variant)">
-      <label for="avatar" class="block font-medium mb-2">Choose header image</label>
-      <input id="headerImage" type="file" accept="image/jpeg,image/png,image/webp,image/gif"
-        (change)="headerImgSelected($event)" class="w-full mb-3" />
-    </div>
-
-    <mat-form-field class="w-full">
-      <mat-label>Display name (can contain emoji codes)</mat-label>
-      <input formControlName="name" matInput />
-    </mat-form-field>
-    <mat-form-field class="w-full">
-      <mat-label>Your bio/description. You can put emoji codes here too. You can use markdown here</mat-label>
-      <textarea matInput placeholder="Description" style="min-height: 20vh" formControlName="description"></textarea>
-    </mat-form-field>
-    <hr />
-    <span>Options</span>
-    <mat-form-field class="w-full">
-      <mat-label>Default post privacy</mat-label>
-      <mat-select [required]="true" formControlName="defaultPostEditorPrivacy">
-        @for (option of privacyOptions; track $index) {
-        <mat-option [value]="option.level">{{ option.name }}</mat-option>
+    <hr>
+    <mat-tab label="{{ 'profile.tabHeaders.profile' | translate }}">
+      <div class="pt-2 px-3 border-round-md mb-4" style="border: 1px solid var(--mat-sys-outline-variant)">
+        <label for="avatar" class="block font-medium mb-2">Choose another avatar</label>
+        <input formControlName="avatar" id="avatar" type="file" accept="image/jpeg,image/png,image/webp,image/gif"
+          (change)="imgSelected($event)" class="w-full mb-3" />
+      </div>
+      <div class="pt-2 px-3 border-round-md mb-4" style="border: 1px solid var(--mat-sys-outline-variant)">
+        <label for="avatar" class="block font-medium mb-2">Choose header image</label>
+        <input id="headerImage" type="file" accept="image/jpeg,image/png,image/webp,image/gif"
+          (change)="headerImgSelected($event)" class="w-full mb-3" />
+      </div>
+      <mat-form-field class="w-full" appearance="outline">
+        <mat-label>Display name (can contain emoji codes)</mat-label>
+        <input formControlName="name" matInput />
+      </mat-form-field>
+      <mat-form-field class="w-full" appearance="outline" >
+        <mat-label>Your bio/description. You can put emoji codes here too. You can use markdown here</mat-label>
+        <textarea matInput placeholder="Description" style="min-height: 20vh" formControlName="description"></textarea>
+      </mat-form-field>
+      <hr />
+      <p [hidden]="loading" class="w-full">Extra information (Fediverse exclusive)</p>
+        @for (attachment of fediAttachments; track $index) {
+        <form [hidden]="loading">
+          <div class="w-full">
+            <mat-form-field class="w-50">
+              <mat-label>Property name</mat-label>
+              <input [ngModelOptions]="{ standalone: true }" [(ngModel)]="fediAttachments[$index].name" matInput />
+            </mat-form-field>
+            <mat-form-field class="w-50">
+              <mat-label>Property value</mat-label>
+              <input [ngModelOptions]="{ standalone: true }" [(ngModel)]="fediAttachments[$index].value" matInput />
+            </mat-form-field>
+          </div>
+        </form>
         }
-      </mat-select>
-    </mat-form-field>
-    <mat-form-field class="w-full">
-      <mat-label>Asks</mat-label>
-      <mat-select [required]="true" formControlName="asksLevel">
-        @for (option of askOptions; track $index) {
-        <mat-option [value]="option.level">{{ option.name }}</mat-option>
-        }
-      </mat-select>
-    </mat-form-field>
-    <div class="w-full">
-      <mat-checkbox formControlName="manuallyAcceptsFollows"></mat-checkbox>
-      <mat-label>Manually accept follows</mat-label>
-    </div>
-    <div class="w-full">
-      <mat-checkbox formControlName="disableForceAltText"></mat-checkbox>
-      <mat-label>Allow uploading media without alt text (enable this only if you're evil)</mat-label>
-    </div>
-    <div class="w-full">
-      <mat-checkbox formControlName="forceClassicLogo"></mat-checkbox>
-      <mat-label>Force classic logo</mat-label>
-    </div>
-    <div class="w-full">
-      <mat-checkbox formControlName="forceClassicVideoPlayer"></mat-checkbox>
-      <mat-label>Force classic video player</mat-label>
-    </div>
-    <div class="w-full">
-      <mat-checkbox formControlName="forceClassicAudioPlayer"></mat-checkbox>
-      <mat-label>Force classic audio player</mat-label>
-    </div>
-    <div class="w-full">
-      <mat-checkbox formControlName="forceClassicMediaView"></mat-checkbox>
-      <mat-label>Force classic media carousel (vertical)</mat-label>
-    </div>
-    <div class="w-full">
-      <mat-checkbox formControlName="disableCW"></mat-checkbox>
-      <mat-label>Disable CW unless post contains muted words</mat-label>
-    </div>
-    <div class="w-full">
-      <mat-checkbox formControlName="enableConfetti"></mat-checkbox>
-      <mat-label>Enable confetti effect when posting and liking posts</mat-label>
-    </div>
-    <div class="w-full">
-      <mat-checkbox formControlName="defaultExploreLocal"></mat-checkbox>
-      <mat-label>Default dashboard is explore local instead of following</mat-label>
-    </div>
-    <mat-accordion>
+      <div [hidden]="loading" (click)="addFediAttachment()">+</div>
+    </mat-tab>
+    <mat-tab label="{{ 'profile.tabHeaders.preferences' | translate }}">
+      <div class="w-full">
+        <mat-checkbox formControlName="manuallyAcceptsFollows"></mat-checkbox>
+        <mat-label>Manually accept follows</mat-label>
+      </div>
+      <div class="w-full">
+        <mat-checkbox formControlName="disableForceAltText"></mat-checkbox>
+        <mat-label>Allow uploading media without alt text (enable this only if you're evil)</mat-label>
+      </div>
+      <div class="w-full">
+        <mat-checkbox formControlName="forceClassicLogo"></mat-checkbox>
+        <mat-label>Force classic logo</mat-label>
+      </div>
+      <div class="w-full">
+        <mat-checkbox formControlName="forceClassicVideoPlayer"></mat-checkbox>
+        <mat-label>Force classic video player</mat-label>
+      </div>
+      <div class="w-full">
+        <mat-checkbox formControlName="forceClassicAudioPlayer"></mat-checkbox>
+        <mat-label>Force classic audio player</mat-label>
+      </div>
+      <div class="w-full">
+        <mat-checkbox formControlName="forceClassicMediaView"></mat-checkbox>
+        <mat-label>Force classic media carousel (vertical)</mat-label>
+      </div>
+      <div class="w-full">
+        <mat-checkbox formControlName="disableCW"></mat-checkbox>
+        <mat-label>Disable CW unless post contains muted words</mat-label>
+      </div>
+      <div class="w-full">
+        <mat-checkbox formControlName="enableConfetti"></mat-checkbox>
+        <mat-label>Enable confetti effect when posting and liking posts</mat-label>
+      </div>
+      <div class="w-full">
+        <mat-checkbox formControlName="defaultExploreLocal"></mat-checkbox>
+        <mat-label>Default dashboard is explore local instead of following</mat-label>
+      </div>
+      <mat-accordion>
+        <mat-expansion-panel hideToggle>
+          <mat-expansion-panel-header>
+            <mat-panel-title> Not recommended options </mat-panel-title>
+          </mat-expansion-panel-header>
+          <div class="w-full">
+            <mat-checkbox formControlName="disableNSFWFilter"></mat-checkbox>
+            <mat-label>Disable NSFW images filter</mat-label>
+          </div>
+          <div class="w-full">
+            <mat-checkbox formControlName="automaticalyExpandPosts"></mat-checkbox>
+            <mat-label>Automatically expand all posts</mat-label>
+          </div>
+        </mat-expansion-panel>
+      </mat-accordion>
+    </mat-tab>
+    <mat-tab label="{{ 'profile.tabHeaders.privacySecurity' | translate }}">
+      <p>Options</p>
+      <mat-form-field class="w-full" appearance="outline">
+        <mat-label>Default post privacy</mat-label>
+        <mat-select [required]="true" formControlName="defaultPostEditorPrivacy">
+          @for (option of privacyOptions; track $index) {
+          <mat-option [value]="option.level">{{ option.name }}</mat-option>
+          }
+        </mat-select>
+      </mat-form-field>
+      <mat-form-field class="w-full" appearance="outline">
+        <mat-label>Asks</mat-label>
+        <mat-select [required]="true" formControlName="asksLevel">
+          @for (option of askOptions; track $index) {
+          <mat-option [value]="option.level">{{ option.name }}</mat-option>
+          }
+        </mat-select>
+      </mat-form-field>
+      {{ 'profile.security.header' | translate }}:
+      <div class="flex align-items-center justify-content-between mt-2">
+        <a routerLink="/recoverPassword"
+          class="font-medium no-underline ml-2 mdc-button w-full mat-primary mat-mdc-unelevated-button cursor-pointer">
+          {{'profile.security.passwordChange' | translate}}
+        </a>
+      </div>
+      <div class="flex align-items-center justify-content-between mt-2">
+        <a routerLink="/mfaSetup"
+          class="font-medium no-underline ml-2 mdc-button w-full mat-primary mat-mdc-unelevated-button cursor-pointer">
+          {{'profile.security.mfa.setup' | translate}}
+        </a>
+      </div>
+    </mat-tab>
+    <mat-tab label="{{ 'profile.tabHeaders.misc' | translate }}">
+      <section id="tags" class="mt-2 w-full flex-row">
+        <mat-form-field class="w-full">
+          <mat-label>Muted words separated by commas</mat-label>
+          <input formControlName="mutedWords" placeholder="Separated by commas" matNativeControl />
+        </mat-form-field>
+        <div *ngIf="editProfileForm.value.mutedWords.split(',').length > 0" class="taglist flex mb-2">
+          Muted phrases:
+          @for (tag of editProfileForm.value.mutedWords.split(','); track $index) {
+          <div *ngIf="tag && tag !== '' && tag.trim() !== ''" class="tag">
+            {{ tag.trim() }}
+          </div>
+          }
+        </div>
+      </section>
+      <mat-accordion>
       <mat-expansion-panel hideToggle>
-        <mat-expansion-panel-header>
-          <mat-panel-title> Not recommended options </mat-panel-title>
-        </mat-expansion-panel-header>
-        <div class="w-full">
-          <mat-checkbox formControlName="disableNSFWFilter"></mat-checkbox>
-          <mat-label>Disable NSFW images filter</mat-label>
-        </div>
-        <div class="w-full">
-          <mat-checkbox formControlName="automaticalyExpandPosts"></mat-checkbox>
-          <mat-label>Automatically expand all posts</mat-label>
-        </div>
-      </mat-expansion-panel>
-    </mat-accordion>
+          <mat-expansion-panel-header>
+            <mat-panel-title> available emojis </mat-panel-title>
+          </mat-expansion-panel-header>
+          <app-emoji-collections (emoji)="emojiClicked($event)"></app-emoji-collections>
+        </mat-expansion-panel>
+      </mat-accordion>
+    </mat-tab>
+    </form>
+  </mat-tab-group>
+
 
     <!--
     <div class="w-full">
@@ -102,69 +165,9 @@
       >
     </mat-card>
     -->
-    <hr />
-    <section id="tags" class="mt-2 w-full flex-row">
-      <mat-form-field class="w-full">
-        <mat-label>Muted words separated by commas</mat-label>
-        <input formControlName="mutedWords" placeholder="Separated by commas" matNativeControl />
-      </mat-form-field>
-      <div *ngIf="editProfileForm.value.mutedWords.split(',').length > 0" class="taglist">
-        Muted phrases:
-        @for (tag of editProfileForm.value.mutedWords.split(','); track $index) {
-        <span *ngIf="tag && tag !== '' && tag.trim() !== ''" class="tag">
-          {{ tag.trim() }}
-        </span>
-        }
-      </div>
-    </section>
-    <hr />
-    <mat-accordion>
-      <mat-expansion-panel hideToggle>
-        <mat-expansion-panel-header>
-          <mat-panel-title> available emojis </mat-panel-title>
-        </mat-expansion-panel-header>
-        <app-emoji-collections (emoji)="emojiClicked($event)"></app-emoji-collections>
-      </mat-expansion-panel>
-    </mat-accordion>
-    <hr />
-    {{ 'profile.security.header' | translate }}:
-    <div class="flex align-items-center justify-content-between mt-2">
-      <a routerLink="/recoverPassword"
-        class="font-medium no-underline ml-2 mdc-button w-full mat-primary mat-mdc-unelevated-button cursor-pointer">
-        {{'profile.security.passwordChange' | translate}}
-      </a>
-    </div>
-    <div class="flex align-items-center justify-content-between mt-2">
-      <a routerLink="/mfaSetup"
-        class="font-medium no-underline ml-2 mdc-button w-full mat-primary mat-mdc-unelevated-button cursor-pointer">
-        {{'profile.security.mfa.setup' | translate}}
-      </a>
-    </div>
-    <hr />
-  </form>
 
-  <div [hidden]="loading" class="w-full">Extra information (Fediverse exclusive)</div>
-
-  @for (attachment of fediAttachments; track $index) {
-  <form [hidden]="loading">
-    <div class="w-full">
-      <mat-form-field class="w-50">
-        <mat-label>Property name</mat-label>
-        <input [ngModelOptions]="{ standalone: true }" [(ngModel)]="fediAttachments[$index].name" matInput />
-      </mat-form-field>
-      <mat-form-field class="w-50">
-        <mat-label>Property value</mat-label>
-        <input [ngModelOptions]="{ standalone: true }" [(ngModel)]="fediAttachments[$index].value" matInput />
-      </mat-form-field>
-    </div>
-  </form>
-  }
-  <div [hidden]="loading" (click)="addFediAttachment()">+</div>
-
-  <hr>
-
-  <button (click)="onSubmit()" [disabled]="!editProfileForm.valid" mat-flat-button color="primary" icon="pi pi-user"
-    class="w-full">
+  <button (click)="onSubmit()" [disabled]="!editProfileForm.valid" mat-raised-button color="primary" icon="pi pi-user"
+    class="w-full mt-4">
     Update profile
   </button>
 </mat-card>

--- a/packages/frontend/src/app/pages/profile/edit-profile/edit-profile.component.html
+++ b/packages/frontend/src/app/pages/profile/edit-profile/edit-profile.component.html
@@ -1,11 +1,11 @@
 <mat-card class="p-3 mb-6 lg:mx-4 wafrn-container">
   <form [hidden]="loading" [formGroup]="editProfileForm" (ngSubmit)="onSubmit()">
-    <div class="pt-2 px-3 border-round-md mb-4" style="border: 1px solid #999">
+    <div class="pt-2 px-3 border-round-md mb-4" style="border: 1px solid var(--mat-sys-outline-variant)">
       <label for="avatar" class="block font-medium mb-2">Choose another avatar</label>
       <input formControlName="avatar" id="avatar" type="file" accept="image/jpeg,image/png,image/webp,image/gif"
         (change)="imgSelected($event)" class="w-full mb-3" />
     </div>
-    <div class="pt-2 px-3 border-round-md mb-4" style="border: 1px solid #999">
+    <div class="pt-2 px-3 border-round-md mb-4" style="border: 1px solid var(--mat-sys-outline-variant)">
       <label for="avatar" class="block font-medium mb-2">Choose header image</label>
       <input id="headerImage" type="file" accept="image/jpeg,image/png,image/webp,image/gif"
         (change)="headerImgSelected($event)" class="w-full mb-3" />

--- a/packages/frontend/src/app/pages/profile/edit-profile/edit-profile.module.ts
+++ b/packages/frontend/src/app/pages/profile/edit-profile/edit-profile.module.ts
@@ -9,6 +9,7 @@ import { MatButtonModule } from '@angular/material/button'
 import { MatInputModule } from '@angular/material/input'
 import { MatSelectModule } from '@angular/material/select'
 import { MatCheckboxModule } from '@angular/material/checkbox'
+import { MatTabsModule } from '@angular/material/tabs';
 import { EmojiCollectionsComponent } from 'src/app/components/emoji-collections/emoji-collections.component'
 import { MatExpansionModule } from '@angular/material/expansion'
 import { TranslateModule } from '@ngx-translate/core'
@@ -35,7 +36,8 @@ const routes: Routes = [
     MatCheckboxModule,
     EmojiCollectionsComponent,
     MatExpansionModule,
-    TranslateModule
+    TranslateModule,
+    MatTabsModule
   ]
 })
 export class EditProfileModule { }

--- a/packages/frontend/src/assets/i18n/en.json
+++ b/packages/frontend/src/assets/i18n/en.json
@@ -108,6 +108,12 @@
                     "totpLabel": "Authenticator App"
                 }
             }
+        },
+        "tabHeaders": {
+            "profile": "Profile",
+            "preferences": "Preferences",
+            "privacySecurity": "Privacy and Security",
+            "misc": "Miscellaneous"
         }
     },
     "ask-dialog-content": {

--- a/packages/frontend/src/styles.scss
+++ b/packages/frontend/src/styles.scss
@@ -245,3 +245,7 @@ body {
 .w-50 {
   width: 50%;
 }
+
+.tag {
+  word-break: break-word;
+}


### PR DESCRIPTION
Instead of dumping all settings into the edit-profile page, it's now organized into tabs, and the page has been renamed to `Preferences and Profile` in the sidebar.

ESPECIALLY the sidebar is preliminary. This just lays the first steps for refactoring the settings as a whole and sets a general direction for how we wanna approach them.

I also snuck three bugfixes in there:
- Made `.tag` wordwrap
- Made the list of muted words into `div`s in a `flex` layout (to avoid weird wrapping)
- un-hardcode the Avatar and Banner outlines.

## Screenshots

![image](https://github.com/user-attachments/assets/f347dd68-6a04-4b7f-ad44-a829a03b0a6d)

---

![Screenshot 2025-04-20 at 23-45-28 Wafrn](https://github.com/user-attachments/assets/ada70b96-8555-4833-bf4d-85b5a74727b6)
![Screenshot 2025-04-20 at 23-45-38 Wafrn](https://github.com/user-attachments/assets/caecdb6f-139c-43c3-a70d-06d2614b53c1)
![Screenshot 2025-04-20 at 23-45-45 Wafrn](https://github.com/user-attachments/assets/2a886efe-45cf-4b34-959d-b012efbe89f4)
![Screenshot 2025-04-20 at 23-45-52 Wafrn](https://github.com/user-attachments/assets/ae108e5d-b275-4dc7-81da-b631c7863e33)
