### PR TITLE
Move Bsky to settings, polish up some styles, fix some stuff

### DIFF
--- a/packages/frontend/src/app/components/navigation-menu/navigation-menu.component.ts
+++ b/packages/frontend/src/app/components/navigation-menu/navigation-menu.component.ts
@@ -350,16 +350,16 @@ export class NavigationMenuComponent implements OnInit, OnDestroy {
               this.hideMenu()
             }
           },
-          {
-            label: this.translateService.instant('menu.settings.enableBluesky'),
-            icon: faBluesky,
-            title: this.translateService.instant('menu.settings.enableBluesky'),
-            visible: true,
-            routerLink: '/profile/enable-bluesky',
-            command: () => {
-              this.hideMenu()
-            }
-          },
+          // {
+          //   label: this.translateService.instant('menu.settings.enableBluesky'),
+          //   icon: faBluesky,
+          //   title: this.translateService.instant('menu.settings.enableBluesky'),
+          //   visible: true,
+          //   routerLink: '/profile/enable-bluesky',
+          //   command: () => {
+          //     this.hideMenu()
+          //   }
+          // },
           {
             label: this.translateService.instant('menu.settings.editProfile'),
             icon: faUserEdit,

--- a/packages/frontend/src/app/pages/profile/edit-profile/edit-profile.component.html
+++ b/packages/frontend/src/app/pages/profile/edit-profile/edit-profile.component.html
@@ -1,5 +1,5 @@
-<mat-card class="p-3 mb-6 lg:mx-4 wafrn-container" style="transition: 1s;">
-  <mat-tab-group mat-stretch-tabs="false" mat-align-tabs="start">
+<mat-card class="p-3 mb-6 lg:mx-4 wafrn-container">
+  <mat-tab-group mat-stretch-tabs="false" mat-align-tabs="start" dynamicHeight preserveContent>
   <form [hidden]="loading" [formGroup]="editProfileForm" (ngSubmit)="onSubmit()">
     <hr>
     <mat-tab label="{{ 'profile.tabHeaders.profile' | translate }}">
@@ -130,7 +130,7 @@
           <mat-label>Muted words separated by commas</mat-label>
           <input formControlName="mutedWords" placeholder="Separated by commas" matNativeControl />
         </mat-form-field>
-        <div *ngIf="editProfileForm.value.mutedWords.split(',').length > 0" class="taglist flex mb-2">
+        <div *ngIf="editProfileForm.value.mutedWords.split(',').length > 0" class="taglist flex flex-wrap mb-2">
           Muted phrases:
           @for (tag of editProfileForm.value.mutedWords.split(','); track $index) {
           <div *ngIf="tag && tag !== '' && tag.trim() !== ''" class="tag">
@@ -149,6 +149,13 @@
       </mat-accordion>
     </mat-tab>
     </form>
+    <mat-tab label="Bluesky">
+      <!-- I swear I'll translate this, don't merge before I do! -->
+      <p>Bluesky integration is still very experimental! Things will absolutely break!</p>
+      <p>Please refer to <a href="https://wafrn.net/faq/user.html#blueskyIntegration">the FAQ</a> to find out what does/doesn't work generally speaking.</p>
+      <p>In the future, we aim to have Bluesky-Specific settings in here, like the ability to change the Bluesky username.</p>
+      <button [disabled]="loading" (click)="enableBluesky()" mat-flat-button class="w-full">Enable bluesky</button>
+    </mat-tab>
   </mat-tab-group>
 
 

--- a/packages/frontend/src/app/pages/profile/edit-profile/edit-profile.component.ts
+++ b/packages/frontend/src/app/pages/profile/edit-profile/edit-profile.component.ts
@@ -177,4 +177,11 @@ export class EditProfileComponent implements OnInit {
   getAttachmentValue() {
     return this.fediAttachments.filter((elem) => elem.name && elem.value)
   }
+
+  enableBluesky() {
+    this.loading = true
+    this.loginService.enableBluesky().then(() => {
+      this.loading = false
+    })
+  }
 }

--- a/packages/frontend/src/assets/i18n/en.json
+++ b/packages/frontend/src/assets/i18n/en.json
@@ -34,7 +34,7 @@
             "title": "Settings",
             "follows": "Manage followers",
             "enableBluesky": "Enable Bluesky",
-            "editProfile": "Edit profile",
+            "editProfile": "Preferences and Profile",
             "themeEditor": "Theme editor",
             "mutedUsers": "Muted users",
             "mutedPosts": "Muted posts",

--- a/packages/frontend/src/styles.scss
+++ b/packages/frontend/src/styles.scss
@@ -249,3 +249,7 @@ body {
 .tag {
   word-break: break-word;
 }
+
+mat-tab-header {
+  margin-bottom: 12px;
+}


### PR DESCRIPTION
The renamed setting that I intended to put into the last commit is here now. additionally the tags in the muted words section do not squish anymore, and bluesky is moved into it's own category in the settings. 

Tab content now dynamically change height for a nicer transition and their content is preserved in the DOM, just to prevent any fuckery happening. the `mat-tab-header` component now has some bottom margins to separate it from the content a bit.

![Screenshot 2025-04-21 at 12-40-47 Wafrn](https://github.com/user-attachments/assets/b32a7f98-e5d4-4026-a014-10616072c99c)

*Should* be ready to merge, if not I'll just open another PR
