### PR TITLE
Fix frontend builds on docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,7 +58,7 @@ services:
     volumes:
       - ./packages/backend/uploads:/wafrn/uploads
       - ./packages/backend/cache:/wafrn/cache
-      - frontend:/wafrn/packages/frontend
+      - frontend:/wafrn/packages/frontend:ro
 
   frontend:
     restart: unless-stopped

--- a/packages/frontend/Dockerfile
+++ b/packages/frontend/Dockerfile
@@ -38,5 +38,10 @@ RUN perl -pi -e 's/\$\{\{([_A-Z]+):-(.*)\}\}/$ENV{$1}||$2/ge' /app/Caddyfile && 
 
 FROM caddy:2
 
+COPY entrypoint.sh /entrypoint.sh
 COPY --from=builder /app/Caddyfile /etc/caddy/Caddyfile
-COPY --from=builder /app/frontend/ /var/www/html/frontend/
+COPY --from=builder /app/frontend/ /app/frontend
+
+ENTRYPOINT [ "/entrypoint.sh" ]
+
+CMD ["caddy", "run", "--config", "/etc/caddy/Caddyfile", "--adapter", "caddyfile"]

--- a/packages/frontend/entrypoint.sh
+++ b/packages/frontend/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+rm -rf /var/www/html/frontend/*
+rm -rf /var/www/html/frontend/.* 2>/dev/null || true
+
+cp -a /app/frontend /var/www/html/
+
+exec "$@"


### PR DESCRIPTION
Bug was introduced in https://github.com/gabboman/wafrn/pull/376 as volumes are not available during build times, hence this was always building an empty image.

Fix is a bit cumbersome as volume mounts are only available during run time, so this would copy over the frontend parts to the volume at each startup, but it works for now.

Likely need a better way to get the "index.html" over to the backend service for SEO purposes though in the future