### PR TITLE
Make quotes optionally collapsed

### DIFF
--- a/packages/frontend/src/app/components/post-fragment/post-fragment.component.html
+++ b/packages/frontend/src/app/components/post-fragment/post-fragment.component.html
@@ -27,7 +27,9 @@
   [ngClass]="{ hidden: (fragment().content_warning || fragment().muted_words_cw) && !showSensitiveContent() }"
 >
   @for (quote of fragment().quotes; track $index) {
-    <div *ngIf="quote" class="quoted-post cursor-pointer">
+    <div *ngIf="quote"
+          class="quoted-post cursor-pointer"
+          [ngClass]="{ 'quote-collapsed': collapseQuotes }">
       <div class="flex">
         <app-post-header class="w-full" [fragment]="quote" [simplified]="true" [disableLink]="true"></app-post-header>
       </div>

--- a/packages/frontend/src/app/components/post-fragment/post-fragment.component.ts
+++ b/packages/frontend/src/app/components/post-fragment/post-fragment.component.ts
@@ -116,6 +116,7 @@ export class PostFragmentComponent implements OnChanges, OnDestroy {
   viewerEnd: Viewer | undefined
 
   forceOldMediaStyle = localStorage.getItem('forceClassicMediaView') == 'true'
+  collapseQuotes = localStorage.getItem('collapseQuotes') == 'true'
 
   nonLinkMediaCount = 0
 

--- a/packages/frontend/src/app/pages/profile/edit-profile/edit-profile.component.html
+++ b/packages/frontend/src/app/pages/profile/edit-profile/edit-profile.component.html
@@ -66,6 +66,10 @@
           <mat-label>Force classic media carousel (vertical)</mat-label>
         </div>
         <div class="w-full">
+          <mat-checkbox formControlName="collapseQuotes"></mat-checkbox>
+          <mat-label>Collapse quotes if too long</mat-label>
+        </div>
+        <div class="w-full">
           <mat-checkbox formControlName="disableCW"></mat-checkbox>
           <mat-label>Disable CW unless post contains muted words</mat-label>
         </div>

--- a/packages/frontend/src/app/pages/profile/edit-profile/edit-profile.component.ts
+++ b/packages/frontend/src/app/pages/profile/edit-profile/edit-profile.component.ts
@@ -52,6 +52,7 @@ export class EditProfileComponent implements OnInit {
     forceClassicVideoPlayer: new FormControl(false),
     enableConfetti: new FormControl(false),
     forceClassicMediaView: new FormControl(false),
+    collapseQuotes: new FormControl(false),
     defaultExploreLocal: new FormControl(false),
     automaticalyExpandPosts: new FormControl(false)
   })
@@ -101,6 +102,9 @@ export class EditProfileComponent implements OnInit {
       this.editProfileForm.controls['enableConfetti'].patchValue(localStorage.getItem('enableConfetti') == 'true')
       this.editProfileForm.controls['forceClassicMediaView'].patchValue(
         localStorage.getItem('forceClassicMediaView') == 'true'
+      )
+      this.editProfileForm.controls['collapseQuotes'].patchValue(
+        localStorage.getItem('collapseQuotes') == 'true'
       )
 
       this.editProfileForm.controls['defaultExploreLocal'].patchValue(

--- a/packages/frontend/src/app/services/login.service.ts
+++ b/packages/frontend/src/app/services/login.service.ts
@@ -239,6 +239,7 @@ export class LoginService {
       forceClassicAudioPlayer: 'wafrn.forceClassicAudioPlayer',
       enableConfetti: 'wafrn.enableConfetti',
       forceClassicMediaView: 'wafrn.forceClassicMediaView',
+      collapseQuotes: 'wafrn.collapseQuotes',
       attachments: 'fediverse.public.attachment',
       alsoKnownAs: 'fediverse.public.alsoKnownAs',
       defaultExploreLocal: 'wafrn.defaultExploreLocal'

--- a/packages/frontend/src/app/styles/post-card.scss
+++ b/packages/frontend/src/app/styles/post-card.scss
@@ -107,7 +107,6 @@
 }
 
 .quoted-post {
-  max-height: 33vh; // ACCORDING TO ALL KNOWNS LAWS OF AVIATION
 	padding: 0.5em;	
 	cursor: pointer !important;
   border-radius: 12px;
@@ -132,7 +131,9 @@
   bottom: 0;
   width: 100%;
   height: 200px;
-  box-shadow: inset -0rem -5rem 5rem -1rem var(--mat-sys-surface-container) !important;
+  /* The -2rem down here is the "stretch" of the quote, so to speak. */
+  /* The higher the value, the closer it becomes to just blocking the whole thing. */
+  box-shadow: inset -0rem -1rem 5rem -1rem var(--mat-sys-surface-container) !important;
 }
 
 // @media (prefers-contrast: more) {


### PR DESCRIPTION
This features:
- A gradient overlay on posts to indicate there's more content
- Relative max-height as to not use absolute pixel heights (bad practice)
- Toggle in the settings to enable/disable this feature

I would've liked to have it take into account the length of the quote, but I wasn't able to find a good way to do that. If someone else wants to help out go right ahead, **would be very much appreciated.**

## Screenshots

![fgxOWRA](https://github.com/user-attachments/assets/6a8f8919-7208-4374-a56c-80627ced4924)
![Screenshot 2025-04-22 at 22-34-13 Wafrn - the social network that respects you](https://github.com/user-attachments/assets/e6d1907c-3815-47fc-aa62-8a9980a113c2)
