### PR TITLE
Add support for daily backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,15 @@ git pull origin main
 docker compose up --build -d
 ```
 
+You can also find a small management script that can backup, restore and update your instance:
+
+```bash
+./install/manage.sh backup
+./install/manage.sh update
+```
+
+By default the installation will create a backup every day and keep it for 10 days
+
 ### BlueSky integraton
 
 To enable the BlueSky integration follow the steps below:

--- a/install/installer.sh
+++ b/install/installer.sh
@@ -102,6 +102,13 @@ source install/env_secret_setup.sh
 docker compose build
 docker compose up -d
 
+echo "---------------------"
+echo "Setting up backups"
+echo "---------------------"
+cat <<CROND_FILE | sudo tee /etc/cron.d/wafrn-backup
+22 3 * * * $(whoami) $HOME/wafrn/install/manage.sh backup
+CROND_FILE
+
 echo
 echo "----"
 echo "Done"

--- a/install/manage.sh
+++ b/install/manage.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+case $1 in
+  update)
+    git pull origin main
+    docker compose up --build -d
+    docker compose logs -t -n 50 -f
+    ;;
+  backup)
+    echo "Cleaning up backup directory"
+    find ~/backup -mtime +10 -type f -delete
+    BACKUP_DIR=~/backup/$(date +"%Y%m%dT%H%M%S")
+    mkdir -p $BACKUP_DIR
+    pushd $BACKUP_DIR
+      echo "Backing up database"
+      docker start wafrn-db-1
+      docker exec wafrn-db-1 pg_dumpall -c | zstd -9 > db.sql.zst
+      echo "Backing up uploads folder"
+      tar --zstd -cf uploads.tar.zst -C $SCRIPT_DIR/../packages/backend/uploads .
+      echo "Backing up bluesky data"
+      docker run --rm -v "wafrn_pds:/pds" -v "$(pwd):/backup" -w /pds node:20-alpine tar c -f - . | zstd > pds.tar.zst
+      echo "Done"
+    popd
+    ;;
+  restore)
+    RESTORE_DIR=$2
+    if [ -d "${RESTORE_DIR}" ] ; then
+      pushd $SCRIPT_DIR/..
+        echo "Stopping instance"
+        docker compose stop
+      popd
+      pushd $RESTORE_DIR
+        echo "Restoring database"
+        docker start wafrn-db-1
+        zstdcat db.sql.zst | docker exec -i wafrn-db-1 psql -X -f - -d postgres
+        echo "Restoring uploads directory"
+        rm -rf $SCRIPT_DIR/../packages/backend/uploads/*
+        tar --zstd -xf uploads.tar.zst -C $SCRIPT_DIR/../packages/backend/uploads
+        echo "Restoring pds data"
+        zstdcat pds.tar.zst | docker run --rm -i -v "wafrn_pds:/pds" -w /pds node:20-alpine sh -c 'rm -rf * && tar x -f -'
+      popd
+      pushd $SCRIPT_DIR/..
+        echo "Restarting intance"
+        docker compose up --build -d
+      popd
+    else
+      echo "Please provide a backup directory to restore"
+    fi
+    ;;
+  *)
+    echo "Valid options:"
+    echo "  update: Download latest wafrn from repository, update and restart"
+    echo "  backup: Create backup of the current wafrn files"
+    echo "  restore: Restore a specific backup"
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
Adds support for a small management script that can backup&restore an instance. This contains:
* Database dump
* Uploads directory
* PDS Volume

It also makes sure to run a backup every day, and keep the last 10 days worth of backups. Backups are stored on local volume, so people should add additional setup to move these to their preferred backup provider.

An easy way to mount the backup directory as an S3 bucket with fuse-s3fs and use any of the S3 compatible storage providers out there