### PR TITLE
add emoji picker to editor, fix emoji alt text recursion

### DIFF
--- a/packages/frontend/src/app/components/avatar-small/avatar-small.component.html
+++ b/packages/frontend/src/app/components/avatar-small/avatar-small.component.html
@@ -2,8 +2,8 @@
   <div
     class="avatar"
     [ngStyle]="{
-      background: 'url(' + avatar + ')',
-      'background-size': 'cover',
+      'background-image': 'url(' + avatar() + ')',
+      'background-size': 'contain',
       'background-repeat': 'no-repeat',
       'background-position': 'center'
     }"

--- a/packages/frontend/src/app/components/avatar-small/avatar-small.component.ts
+++ b/packages/frontend/src/app/components/avatar-small/avatar-small.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common'
-import { Component, OnInit, input } from '@angular/core'
+import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core'
 import { RouterModule } from '@angular/router'
 import { SimplifiedUser } from '../../interfaces/simplified-user'
 import { EnvironmentService } from '../../services/environment.service'
@@ -9,22 +9,20 @@ import { BlogLinkModule } from 'src/app/directives/blog-link/blog-link.module'
   selector: 'app-avatar-small',
   imports: [CommonModule, RouterModule, BlogLinkModule],
   templateUrl: './avatar-small.component.html',
-  styleUrl: './avatar-small.component.scss'
+  styleUrl: './avatar-small.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class AvatarSmallComponent implements OnInit {
-  readonly user = input.required<SimplifiedUser>();
+export class AvatarSmallComponent {
+  user = input.required<SimplifiedUser>();
   readonly disabled = input(false);
-  avatar: string = ''
-
-  ngOnInit(): void {
+  avatar = computed(() => {
     const user = this.user();
-    this.avatar =
-      EnvironmentService.environment.externalCacheurl +
+    return EnvironmentService.environment.externalCacheurl +
       encodeURIComponent(
         user.url.startsWith('@')
           ? user.avatar
           : EnvironmentService.environment.baseMediaUrl + user.avatar
       ) +
       '&avatar=true'
-  }
+  });
 }

--- a/packages/frontend/src/app/components/emoji-collections/emoji-collections.component.ts
+++ b/packages/frontend/src/app/components/emoji-collections/emoji-collections.component.ts
@@ -101,6 +101,11 @@ export class EmojiCollectionsComponent implements OnDestroy {
   }
 
   toggleCollection(index: number) {
+    if (index < 0) {
+      this.includedCollections.clear();
+      this.includedCollectionsSize.set(this.includedCollections.size);
+      return;
+    }
     if (this.includedCollections.has(index)) {
       this.includedCollections.delete(index);
       this.includedCollectionsSize.set(this.includedCollections.size);

--- a/packages/frontend/src/app/components/new-editor/new-editor.component.html
+++ b/packages/frontend/src/app/components/new-editor/new-editor.component.html
@@ -43,6 +43,18 @@
           <fa-icon size="lg" [icon]="contentWarningIcon"></fa-icon>
         }
       </button>
+      <button
+        class="input-height-btn"
+        mat-icon-button
+        (click)="openEmojiSelection()"
+        matTooltip="{{ 'editor.insertEmojiTooltip' | translate }}"
+      >
+        <svg width="20px" height="20px" viewBox="0 0 1000 1000" fill="currentColor" class="vertical-align-middle">
+          <path
+            d="M958 104h-62V43q0-17-12-29T855 2h-87q-17 0-29 12t-12 29v61h-62q-17 0-29 12t-12 29v4q-81-34-169-34-116 0-217 59-97 57-154 154-58 100-58 216.5T84 761q57 98 154 155 101 58 217.5 58T672 916q97-57 154-155 59-100 59-216 0-88-34-168h4q17 0 29-12t12-29v-62h62q17 0 29-12t12-29v-88q0-17-12-29t-29-12zM644 348q29 0 49.5 20.5t20.5 49-20.5 49T644 487t-49.5-20.5-20.5-49 20.5-49T644 348zm-377 0q29 0 49.5 20.5t20.5 49-20.5 49T267 487t-49.5-20.5-20.5-49 20.5-49T267 348zm473 255q-10 70-50.5 126.5t-102 88.5-132 32-132-32-102-88.5T171 603q-2-16 8.5-27.5T206 564h499q16 0 26.5 11.5T740 603zm218-370H855v103h-87V233H665v-88h103V43h87v102h103v88z"
+          />
+        </svg>
+      </button>
       <!--
       <button
         [matBadge]="mentionedUsers.length"

--- a/packages/frontend/src/app/components/new-editor/new-editor.component.ts
+++ b/packages/frontend/src/app/components/new-editor/new-editor.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common'
-import { Component, computed, ElementRef, HostListener, OnDestroy, ViewChild, ViewChildren } from '@angular/core'
+import { Component, HostListener, inject, OnDestroy, ViewChild } from '@angular/core'
 import { FormControl, FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms'
 import { MatButtonModule } from '@angular/material/button'
 import { MatCardModule } from '@angular/material/card'
@@ -51,6 +51,9 @@ import { InfoCardComponent } from '../info-card/info-card.component'
 import { TranslateModule } from '@ngx-translate/core'
 import { SimplifiedUser } from 'src/app/interfaces/simplified-user'
 import { MatBadgeModule } from '@angular/material/badge'
+import { EmojiPickerComponent } from '../emoji-picker/emoji-picker.component'
+import { Emoji } from 'src/app/interfaces/emoji'
+import { Dialog } from '@angular/cdk/dialog'
 
 @Component({
   selector: 'app-new-editor',
@@ -77,7 +80,7 @@ import { MatBadgeModule } from '@angular/material/badge'
     MatDialogModule,
     TranslateModule,
     MatBadgeModule,
-    MatChipsModule
+    MatChipsModule,
   ],
   templateUrl: './new-editor.component.html',
   styleUrl: './new-editor.component.scss'
@@ -92,6 +95,7 @@ export class NewEditorComponent implements OnDestroy {
   ]
   quoteOpen = false
   data: EditorData | undefined
+  emojiDialog = inject(Dialog);
   editing = false
   baseMediaUrl = EnvironmentService.environment.baseMediaUrl
   cacheurl = EnvironmentService.environment.externalCacheurl
@@ -533,5 +537,17 @@ export class NewEditorComponent implements OnDestroy {
 
   removeMention(index: number) {
     this.mentionedUsers.splice(index, 1)
+  }
+
+  openEmojiSelection(): void {
+    const textarea = document.getElementById('postCreatorContent') as HTMLTextAreaElement
+    const pos = textarea.selectionStart;
+    const dialogRef = this.emojiDialog.open<Emoji>(EmojiPickerComponent);
+
+    dialogRef.closed.subscribe(result => {
+      if (result) {
+        textarea.value = textarea.value.slice(0, pos) + result.name + textarea.value.slice(pos);
+      }
+    })
   }
 }

--- a/packages/frontend/src/app/components/snappy/snappy.service.ts
+++ b/packages/frontend/src/app/components/snappy/snappy.service.ts
@@ -19,6 +19,7 @@ export class SnappyService {
    * @param data - The data to be consumed, must be decorated with `@SnappyInjecatble`
    */
   public injectData(data: any) {
+    if (!(data?.Ψsnappyid)) return;
     this.stream.next({ token: data.Ψsnappyid, data: data });
   }
 

--- a/packages/frontend/src/app/directives/post-link/post-link.directive.ts
+++ b/packages/frontend/src/app/directives/post-link/post-link.directive.ts
@@ -22,7 +22,7 @@ export class PostLinkDirective implements OnInit {
   onClick(event: MouseEvent): void {
     if (event.button === 0) {
       event.preventDefault();
-      const wrapper = new SnappyPostData(this.postLink);
+      const wrapper: any = this.postLink.parentCollection.length > 0 ? new SnappyPostData(this.postLink) : null;
       this.snappy.navigateTo('/fediverse/post/' + this.postLinkId!, wrapper);
     }
   }

--- a/packages/frontend/src/app/services/posts.service.ts
+++ b/packages/frontend/src/app/services/posts.service.ts
@@ -255,7 +255,8 @@ export class PostsService {
   }
 
   processPostNew(unlinked: unlinkedPosts): ProcessedPost[][] {
-    this.processedQuotes = unlinked.quotedPosts.map((quote) => this.processSinglePost({ ...unlinked, posts: [quote] }, this.processedQuotes));
+    const fake: ProcessedPost[] = [];
+    this.processedQuotes = unlinked.quotedPosts.map((quote) => this.processSinglePost({ ...unlinked, posts: [quote] }, fake));
     const res = unlinked.posts
       .filter((post) => !!post)
       .map((elem) => {
@@ -308,8 +309,8 @@ export class PostsService {
     const polls = elem ? unlinked.polls.filter((poll) => poll.postId === elem.id) : []
     const medias = elem
       ? unlinked.medias.filter((media) => {
-          return media.postId === elem.id
-        })
+        return media.postId === elem.id
+      })
       : []
     if (user.name) {
       user.name = user.name.replaceAll('‏', '')
@@ -324,26 +325,26 @@ export class PostsService {
     }
     const mentionedUsers = elem
       ? unlinked.mentions
-          .filter((mention) => mention.post === elem.id)
-          .map((mention) => unlinked.users.find((usr) => usr.id === mention.userMentioned))
-          .filter((mention) => mention !== undefined)
+        .filter((mention) => mention.post === elem.id)
+        .map((mention) => unlinked.users.find((usr) => usr.id === mention.userMentioned))
+        .filter((mention) => mention !== undefined)
       : []
     let emojiReactions: PostEmojiReaction[] = elem
       ? unlinked.emojiRelations.postEmojiReactions.filter((emoji) => emoji.postId === elem.id)
       : []
     const likesAsEmojiReactions: PostEmojiReaction[] = elem
       ? unlinked.likes
-          .filter((like) => like.postId === elem.id)
-          .map((likeUserId) => {
-            return {
-              emojiId: 'Like',
-              postId: elem.id,
-              userId: likeUserId.userId,
-              content: '♥️',
-              //emoji?: Emoji;
-              user: unlinked.users.find((usr) => usr.id === likeUserId.userId)
-            }
-          })
+        .filter((like) => like.postId === elem.id)
+        .map((likeUserId) => {
+          return {
+            emojiId: 'Like',
+            postId: elem.id,
+            userId: likeUserId.userId,
+            content: '♥️',
+            //emoji?: Emoji;
+            user: unlinked.users.find((usr) => usr.id === likeUserId.userId)
+          }
+        })
       : []
     emojiReactions = emojiReactions.map((react) => {
       return {
@@ -358,8 +359,8 @@ export class PostsService {
     const links = parsedAsHTML.getElementsByTagName('a')
     const quotes = elem
       ? unlinked.quotes
-          .filter((quote) => quote.quoterPostId === elem.id)
-          .map((quote) => this.processedQuotes.find((pst) => pst.id === quote.quotedPostId) as ProcessedPost)
+        .filter((quote) => quote.quoterPostId === elem.id)
+        .map((quote) => this.processedQuotes.find((pst) => pst.id === quote.quotedPostId) as ProcessedPost)
       : []
     Array.from(links).forEach((link, index) => {
       const youtubeMatch = Array.from(link.href.matchAll(this.youtubeRegex))
@@ -625,8 +626,8 @@ export class PostsService {
     const mentionRemoteUrls = post.mentionPost ? post.mentionPost?.map((elem) => elem.url) : []
     const mentionedHosts = post.mentionPost
       ? post.mentionPost?.map(
-          (elem) => this.getURL(elem.remoteId ? elem.remoteId : 'https://adomainthatdoesnotexist.google.com').hostname
-        )
+        (elem) => this.getURL(elem.remoteId ? elem.remoteId : 'https://adomainthatdoesnotexist.google.com').hostname
+      )
       : []
     const hostUrl = this.getURL(EnvironmentService.environment.frontUrl).hostname
     Array.from(links).forEach((link) => {
@@ -634,10 +635,9 @@ export class PostsService {
       if (link.innerText === link.href && youtubeMatch) {
         // NOTE: Since this should not be part of the image Viewer, we have to add then no-viewer class to be checked for later
         Array.from(youtubeMatch).forEach((youtubeString) => {
-          link.innerHTML = `<div class="watermark"><!-- Watermark container --><div class="watermark__inner"><!-- The watermark --><div class="watermark__body"><img alt="youtube logo" class="yt-watermark no-viewer" loading="lazy" src="/assets/img/youtube_logo.png"></div></div><img class="yt-thumbnail" src="${
-            EnvironmentService.environment.externalCacheurl +
+          link.innerHTML = `<div class="watermark"><!-- Watermark container --><div class="watermark__inner"><!-- The watermark --><div class="watermark__body"><img alt="youtube logo" class="yt-watermark no-viewer" loading="lazy" src="/assets/img/youtube_logo.png"></div></div><img class="yt-thumbnail" src="${EnvironmentService.environment.externalCacheurl +
             encodeURIComponent(`https://img.youtube.com/vi/${youtubeString[6]}/hqdefault.jpg`)
-          }" loading="lazy" alt="Thumbnail for video"></div>`
+            }" loading="lazy" alt="Thumbnail for video"></div>`
         })
       }
       // replace mentioned users with wafrn version of profile.
@@ -690,7 +690,11 @@ export class PostsService {
 
     sanitized = sanitized.replaceAll(this.wafrnMediaRegex, '')
 
+    let emojiset = new Set<string>();
     post.emojis.forEach((emoji) => {
+      // Post can include the same emoji more than once, causing recursive behaviour with alt/title text
+      if (emojiset.has(emoji.name)) return;
+      emojiset.add(emoji.name);
       const strToReplace = emoji.name.startsWith(':') ? emoji.name : `:${emoji.name}:`
       sanitized = sanitized.replaceAll(strToReplace, this.emojiToHtml(emoji))
     })

--- a/packages/frontend/src/assets/i18n/en.json
+++ b/packages/frontend/src/assets/i18n/en.json
@@ -79,6 +79,7 @@
         "ariaLabelQuoteSetter": "Enable the quote setter",
         "uploadMediaTooltip": "Upload Media",
         "contentWarningTooltip": "Content Warning",
+        "insertEmojiTooltip": "Insert emoji",
         "hiddenMentionsTooltip": "Other mentioned users"
     },
     "profile": {


### PR DESCRIPTION
Couple of tweaks:
- Add emoji picker button to post editor
- Fix emoji images not updating in emoji suggestions menu
- Fix issue with emoji alt text/title text being recursively replaced
- Verify that snappy-router data is valid before adding to data queue
- Fix "*" button not resetting included collections within the emoji picker