### PR TITLE
add recent emojis, better use of emoji picker space

### DIFF
--- a/packages/frontend/src/app/components/emoji-collections/emoji-collections.component.html
+++ b/packages/frontend/src/app/components/emoji-collections/emoji-collections.component.html
@@ -4,14 +4,21 @@
       <input [(ngModel)]="filterText" matInput />
     </mat-form-field>
 
-  <div class="emoji-container">
+  <div #emojiContainer class="emoji-container">
     <div class="emoji-sidebar">
       <button
         [class.emoji-active-collection]="this.collectionHas(-1)"
         class="emoji-sidebar-child p-2 flex align-content-center justify-content-center cursor-pointer bg-transparent emoji-collection-button"
         (click)="this.toggleCollection(-1)"
       >
-        *
+        <span title="All emojis" class="post-emoji-header">*</span>
+      </button>
+      <button
+        [class.emoji-active-collection]="this.collectionHas(-2)"
+        class="emoji-sidebar-child p-2 flex align-content-center justify-content-center cursor-pointer bg-transparent emoji-collection-button"
+        (click)="this.toggleCollection(-2)"
+      >
+        <fa-icon class="post-emoji-header" title="Recent emojis" [icon]="clockIcon"></fa-icon>
       </button>
       @for (emojiCollection of emojiCollections; track $index) {
         @let emoji = emojiCollection.emojis[0];
@@ -26,25 +33,25 @@
           <img
             *ngIf="emoji.url"
             loading="lazy"
-            class="post-emoji-preview mr-2 ml-2"
+            class="post-emoji-header mr-2 ml-2"
             [src]="baseMediaUrl + emoji.url"
             [alt]="emojiCollection.name"
             [title]="emojiCollection.name"
           />
         </button>
       }
-      <hr />
     </div>
+    <hr />
 
-    <cdk-virtual-scroll-viewport itemSize="50" class="emoji-viewport" minBufferPx="300" maxBufferPx="400">
-      <div *cdkVirtualFor="let row of this.emojiRenderable()" class="emoji-row">
+    <cdk-virtual-scroll-viewport itemSize="50" class="emoji-viewport" minBufferPx="400" maxBufferPx="500">
+      <div *cdkVirtualFor="let row of this.emojiRenderable()" class="emoji-row" [class.emoji-header]="row.tag === 0">
         @if (row.tag === 0) {
-          {{ row.name }}
+          <span>{{ row.name }}</span>
         } @else {
           @for (emoji of row.emos; track $index) {
             <button
               mat-flat-button
-              [matTooltip]="emoji.name"
+              [title]="emoji.name"
               (click)="click(emoji)"
               class="p-2 flex align-content-center justify-content-center cursor-pointer bg-transparent emoji-item"
             >

--- a/packages/frontend/src/app/components/emoji-collections/emoji-collections.component.scss
+++ b/packages/frontend/src/app/components/emoji-collections/emoji-collections.component.scss
@@ -1,6 +1,8 @@
+$narrow: 800px;
+
 .post-emoji-preview {
-  max-width: 1.5em;
-  max-height: 1.5em;
+  width: 32px;
+  height: 32px;
 }
 
 .emoji-position {
@@ -10,6 +12,9 @@
 .emoji-container {
   display: flex;
   flex-direction: row;
+  @media (max-width: $narrow) {
+    flex-direction: column-reverse;
+  }
 }
 
 .emoji-viewport {
@@ -23,6 +28,14 @@
   display: flex;
   flex-direction: column;
   row-gap: 5px;
+}
+
+.emoji-header {
+  text-align: left;
+  justify-content: end !important;
+  align-items:center;
+  padding-left: 1em;
+  padding-right: 1em;
 }
 
 .emoji-row {
@@ -50,6 +63,12 @@
   text-align: center;
   align-items: center;
   row-gap: 0.5rem;
+  @media (max-width: $narrow) {
+    flex-direction: row;
+    height: 64px;
+    overflow-y: hidden;
+    overflow-x: scroll;
+  }
 }
 .emoji-sidebar-child {
   text-align: center;
@@ -59,9 +78,17 @@
   background-color: var(--mat-sys-inverse-primary) !important;
 }
 .emoji-collection-button {
-  width: 2em;
-  height: 2em;
+  width: 42px;
+  height: 42px;
   border-radius: 50%;
   text-decoration: none;
   border: none;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;margin: auto;
+
+  span {
+    line-height:40px;
+  }
 }

--- a/packages/frontend/src/app/components/emoji-collections/emoji-collections.component.ts
+++ b/packages/frontend/src/app/components/emoji-collections/emoji-collections.component.ts
@@ -1,12 +1,12 @@
 import { CommonModule } from '@angular/common'
-import { Component, computed, EventEmitter, model, OnDestroy, Output, signal } from '@angular/core'
+import { AfterViewInit, Component, computed, ElementRef, HostListener, model, OnDestroy, output, signal, ViewChild } from '@angular/core'
 import { FormsModule } from '@angular/forms'
 import { MatButtonModule } from '@angular/material/button'
 import { MatExpansionModule } from '@angular/material/expansion'
 import { MatInputModule } from '@angular/material/input'
 import { MatTooltipModule } from '@angular/material/tooltip'
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome'
-import { faCopy } from '@fortawesome/free-solid-svg-icons'
+import { faCopy, faClock } from '@fortawesome/free-solid-svg-icons'
 import { Subscription } from 'rxjs'
 import { Emoji } from '../../interfaces/emoji'
 import { EmojiCollection } from '../../interfaces/emoji-collection'
@@ -40,44 +40,81 @@ export interface EmojiRow {
   templateUrl: './emoji-collections.component.html',
   styleUrl: './emoji-collections.component.scss',
 })
-export class EmojiCollectionsComponent implements OnDestroy {
-  private static readonly emoji_per_row = 4;
+export class EmojiCollectionsComponent implements AfterViewInit, OnDestroy {
+  @ViewChild('emojiContainer')
+  emojiElement!: ElementRef<HTMLElement>;
+
+  readonly emojiWidth = 58;
+  readonly maxRecents = 32;
+  emojiPerRow = signal(4);
 
   // No point having a reference as a signal.
   includedCollections: Set<number> = new Set();
   includedCollectionsSize = signal<number>(0);
+  filterText = model<string>('');
 
+  // Computed upon changes to `includedCollectionsSize` and `filterText`
   emojiRenderable = computed<EmojiRow[]>(() => {
     const renderable: EmojiRow[] = [];
 
+    // Our recent emojis are stored in local storage
+    // -2 is our sentinel value for recents
+    if (this.includedCollectionsSize() === 0 || this.includedCollections.has(-2)) {
+      let recents = localStorage.getItem("recentEmoji");
+      recents ??= "[]";
+      let localEmos = JSON.parse(recents) as Emoji[];
+
+      if (localEmos) {
+        const header: EmojiRow = { tag: EmojiRenderType.Header, name: "Recent emojis", emos: [] };
+        renderable.push(header);
+        this.createEmojiRows(this.filterText(), localEmos, renderable, true);
+      }
+    }
+
+
     for (let i = 0; i < this.emojiCollections.length; i++) {
+      // If we are not including any collections, we render everything!
       if (this.includedCollectionsSize() != 0 && !this.includedCollections.has(i)) continue;
+
       let collection = this.emojiCollections[i];
+
       // Create a element for this collection's header
       const header: EmojiRow = { tag: EmojiRenderType.Header, name: collection.name, emos: [] };
       renderable.push(header);
-      let count = 1;
-      let row: Emoji[] = [];
-      // Create elements for each row of emoji
-      for (let emoji of collection.emojis) {
-        if (emoji.name.toLowerCase().includes(this.filterText().toLowerCase())) {
-          row.push(emoji);
-          if (++count > EmojiCollectionsComponent.emoji_per_row) {
-            const emojiRow: EmojiRow = { tag: EmojiRenderType.Row, emos: [...row], name: '' };
-            renderable.push(emojiRow);
-            count = 1;
-            row = [];
-          }
-        }
-      }
+      this.createEmojiRows(this.filterText(), collection.emojis, renderable);
     }
     return renderable;
   });
+
+  createEmojiRows(query: string, emojis: Emoji[], out: EmojiRow[], reverse: boolean = false) {
+    let count = 1;
+    let row = [];
+    // Create elements for each row of emoji
+    let i = reverse ? emojis.length - 1 : 0;
+    for (; reverse ? i >= 0 : i < emojis.length; reverse ? i-- : i++) {
+      let emoji = emojis[i];
+      if (!query || emoji.name.toLowerCase().includes(this.filterText().toLowerCase())) {
+        row.push(emoji);
+        if (++count > this.emojiPerRow()) {
+          const emojiRow: EmojiRow = { tag: EmojiRenderType.Row, emos: [...row], name: '' };
+          out.push(emojiRow);
+          count = 1;
+          row = [];
+        }
+      }
+    }
+    // Our row might not have been added!
+    if (row.length > 0) {
+      const emojiRow: EmojiRow = { tag: EmojiRenderType.Row, emos: [...row], name: '' };
+      out.push(emojiRow);
+    }
+  }
+
   copyIcon = faCopy
-  filterText = model<string>('');
+  clockIcon = faClock
   emojiCollections: EmojiCollection[] = []
   subscription: Subscription
-  @Output() emoji: EventEmitter<Emoji> = new EventEmitter<Emoji>()
+  emoji = output<Emoji>()
 
   baseMediaUrl = EnvironmentService.environment.baseMediaUrl
 
@@ -86,12 +123,16 @@ export class EmojiCollectionsComponent implements OnDestroy {
       this.emojiCollections = this.postService.emojiCollections
     })
   }
+  ngAfterViewInit(): void {
+    this.updateDimensions();
+  }
 
   ngOnDestroy(): void {
     this.subscription.unsubscribe()
   }
 
   click(emoji: Emoji) {
+    this.addToRecents(emoji);
     this.emoji.emit({
       id: emoji.id,
       name: emoji.url ? emoji.name : emoji.id,
@@ -100,12 +141,32 @@ export class EmojiCollectionsComponent implements OnDestroy {
     })
   }
 
+  addToRecents(emoji: Emoji) {
+    let recents = localStorage.getItem("recentEmoji");
+    recents ??= "[]";
+    let emos = JSON.parse(recents) as Emoji[];
+    let index = emos.findIndex((e) => { return emoji.name === e.name });
+    if (index >= 0) {
+      emos.push(emos.splice(index, 1)[0]);
+    } else {
+      emos.push(emoji);
+    }
+    if (emos.length > this.maxRecents) {
+      emos.splice(0, 1);
+    }
+    localStorage.setItem("recentEmoji", JSON.stringify(emos));
+  }
+
   toggleCollection(index: number) {
-    if (index < 0) {
+    // We use -1 as a sentinel value to indicate that "*" (all) was selected.
+    if (index === -1) {
       this.includedCollections.clear();
       this.includedCollectionsSize.set(this.includedCollections.size);
       return;
     }
+
+    // Otherwise, toggle the included collection. We explicitly track the size
+    // as we do not mutate the reference to the hashmap.
     if (this.includedCollections.has(index)) {
       this.includedCollections.delete(index);
       this.includedCollectionsSize.set(this.includedCollections.size);
@@ -116,7 +177,8 @@ export class EmojiCollectionsComponent implements OnDestroy {
   }
 
   collectionHas(index: number): boolean {
-    if (index < 0) {
+    // We use -1 as a sentinel value to indicate that "*" (all) was selected.
+    if (index === -1) {
       return this.includedCollections.size === 0;
     }
     return this.includedCollections.has(index) && this.includedCollections.size != 0;
@@ -124,5 +186,14 @@ export class EmojiCollectionsComponent implements OnDestroy {
 
   showCollection(collection: EmojiCollection): boolean {
     return collection.emojis.map((elem) => elem.name).some((elem) => elem.includes(this.filterText()))
+  }
+
+  updateDimensions() {
+    this.emojiPerRow.set(this.emojiElement.nativeElement.offsetWidth / this.emojiWidth);
+  }
+
+  @HostListener('window:resize', ['$event'])
+  onResize() {
+    this.updateDimensions();
   }
 }

--- a/packages/frontend/src/app/components/emoji-picker/emoji-picker.component.html
+++ b/packages/frontend/src/app/components/emoji-picker/emoji-picker.component.html
@@ -1,4 +1,7 @@
 <div class="p-1 emojireact-overlay">
-  <p class="text-xs">Mastodon does not support emojireacts yet</p>
+  <div class="emojireact-overlay-header">
+    <p class="text-xs"><i>Mastodon does not support emoji reactions yet</i></p>
+    <button title="Close" mat-flat-button (click)="closeDialog()">X</button>
+  </div>
   <app-emoji-collections (emoji)="reactToPost($event)"></app-emoji-collections>
 </div>

--- a/packages/frontend/src/app/components/emoji-picker/emoji-picker.component.scss
+++ b/packages/frontend/src/app/components/emoji-picker/emoji-picker.component.scss
@@ -1,13 +1,21 @@
+$narrow: 800px;
+.emojireact-overlay-header {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+}
+
 :host {
+  width: 50vw;
   display: block;
   padding: 8px 16px;
-  max-width: 24rem;
-  max-height: 32rem;
   overflow-x: hidden;
   overflow-y: hidden;
   background-color: var(--mat-sys-surface-container-high);
   border-radius: var(--mat-sys-corner-small);
   box-shadow: var(--mat-sys-level3);
   overscroll-behavior: contain;
-  z-index: 9999
+  @media (max-width: $narrow) {
+    width: 100%;
+  }
 }

--- a/packages/frontend/src/app/components/emoji-picker/emoji-picker.component.ts
+++ b/packages/frontend/src/app/components/emoji-picker/emoji-picker.component.ts
@@ -3,12 +3,14 @@ import { DialogRef } from '@angular/cdk/dialog';
 import { EmojiCollectionsComponent } from '../emoji-collections/emoji-collections.component';
 import { Emoji } from 'src/app/interfaces/emoji';
 import { CommonModule } from '@angular/common';
+import { MatButtonModule } from '@angular/material/button';
 
 @Component({
-  selector: 'app-emoji-react',
+  selector: 'app-emoji-picker',
   imports: [
     CommonModule,
     EmojiCollectionsComponent,
+    MatButtonModule
   ],
   styleUrl: './emoji-picker.component.scss',
   templateUrl: './emoji-picker.component.html',
@@ -18,5 +20,9 @@ export class EmojiPickerComponent {
 
   reactToPost(e: Emoji) {
     this.dialogRef.close(e);
+  }
+
+  closeDialog() {
+    this.dialogRef.close();
   }
 }

--- a/packages/frontend/src/app/components/emoji-react/emoji-react.component.scss
+++ b/packages/frontend/src/app/components/emoji-react/emoji-react.component.scss
@@ -5,9 +5,8 @@ button {
   border-radius: var(--mat-sys-corner-small);
 }
 
+
 .emojireact-overlay {
-  max-width: 24rem;
-  max-height: 32rem;
   overflow-x: hidden;
   overflow-y: auto;
   background-color: var(--mat-sys-surface-container-high);

--- a/packages/frontend/src/app/components/emoji-react/emoji-react.component.ts
+++ b/packages/frontend/src/app/components/emoji-react/emoji-react.component.ts
@@ -31,7 +31,9 @@ export class EmojiReactComponent {
     this.scrollStrategy = this.overlay.scrollStrategies.reposition()
   }
   openDialog(): void {
-    const dialogRef = this.dialog.open<Emoji>(EmojiPickerComponent)
+    const dialogRef = this.dialog.open<Emoji>(EmojiPickerComponent, {
+      autoFocus: false
+    });
 
     dialogRef.closed.subscribe((result) => {
       if (result) {

--- a/packages/frontend/src/app/pages/view-blog/view-blog.component.ts
+++ b/packages/frontend/src/app/pages/view-blog/view-blog.component.ts
@@ -193,7 +193,9 @@ export class ViewBlogComponent implements OnInit, OnDestroy, SnappyHide, SnappyS
       }
 
       if (userResponseToCustomThemes === 0) {
-        const dialogRef = this.dialog.open(AcceptThemeComponent)
+        const dialogRef = this.dialog.open(AcceptThemeComponent, {
+          autoFocus: false
+        });
         dialogRef.afterClosed().subscribe(() => {
           userResponseToCustomThemes = this.themeService.hasUserAcceptedCustomThemes()
           if (userResponseToCustomThemes === 2) {


### PR DESCRIPTION
A few updates to the emoji picker:
- Recent emojis, up to 32, in local storage.
- Better accommodate different screensizes
- Don't auto-focus dialogue
- Fix issue where last row of emojis was not added to picker
- Switch to title tooltips for emoji
  - Scrolling with matTooltip is unfortunately a little unpleasant

<details>
<summary> Picker on widescreen </summary>

![image](https://github.com/user-attachments/assets/1ae7cc16-8201-4b23-9c29-b43288e73cac)
</details>

<details>
<summary> Picker on narrow screen </summary>

![image](https://github.com/user-attachments/assets/51dbf5b4-b201-43e2-be00-786eff87a478)
</details>


(ignore the duplicate recent in these screenshots)