### PR TITLE
improve emoji picker performance

### DIFF
--- a/packages/frontend/src/app/components/emoji-collections/emoji-collections.component.html
+++ b/packages/frontend/src/app/components/emoji-collections/emoji-collections.component.html
@@ -1,71 +1,82 @@
-<div class="emoji-position">
-    <mat-form-field class="w-full mt-2">
-      <mat-label>Search available emojis</mat-label>
-      <input [(ngModel)]="filterText" matInput />
-    </mat-form-field>
+<mat-form-field class="w-full mt-2">
+  <mat-label>Search available emojis</mat-label>
+  <input [(ngModel)]="filterText" matInput />
+</mat-form-field>
 
+<div>
   <div #emojiContainer class="emoji-container">
-    <div class="emoji-sidebar">
-      <button
-        [class.emoji-active-collection]="this.collectionHas(-1)"
-        class="emoji-sidebar-child p-2 flex align-content-center justify-content-center cursor-pointer bg-transparent emoji-collection-button"
-        (click)="this.toggleCollection(-1)"
-      >
-        <span title="All emojis" class="post-emoji-header">*</span>
-      </button>
-      <button
-        [class.emoji-active-collection]="this.collectionHas(-2)"
-        class="emoji-sidebar-child p-2 flex align-content-center justify-content-center cursor-pointer bg-transparent emoji-collection-button"
-        (click)="this.toggleCollection(-2)"
-      >
-        <fa-icon class="post-emoji-header" title="Recent emojis" [icon]="clockIcon"></fa-icon>
-      </button>
-      @for (emojiCollection of emojiCollections; track $index) {
-        @let emoji = emojiCollection.emojis[0];
+    <div>
+      <div class="emoji-sidebar">
         <button
-          [class.emoji-active-collection]="this.collectionHas($index)"
+          [class.emoji-active-collection]="this.collectionHas(-1)"
           class="emoji-sidebar-child p-2 flex align-content-center justify-content-center cursor-pointer bg-transparent emoji-collection-button"
-          (click)="toggleCollection($index)"
+          (click)="this.toggleCollection(-1)"
         >
-          @if (!emoji.url) {
-            {{ emoji.id }}
-          }
-          <img
-            *ngIf="emoji.url"
-            loading="lazy"
-            class="post-emoji-header mr-2 ml-2"
-            [src]="baseMediaUrl + emoji.url"
-            [alt]="emojiCollection.name"
-            [title]="emojiCollection.name"
-          />
+          <span title="All emojis">*</span>
         </button>
-      }
+        <button
+          [class.emoji-active-collection]="this.collectionHas(-2)"
+          class="emoji-sidebar-child p-2 flex align-content-center justify-content-center cursor-pointer bg-transparent emoji-collection-button"
+          (click)="this.toggleCollection(-2)"
+        >
+          <span><fa-icon title="Recent emojis" [icon]="clockIcon"></fa-icon></span>
+        </button>
+        @for (emojiCollection of emojiCollections; track $index) {
+          @let emoji = emojiCollection.emojis[0];
+          <button
+            [class.emoji-active-collection]="this.collectionHas($index)"
+            class="emoji-sidebar-child p-2 flex align-content-center justify-content-center cursor-pointer bg-transparent emoji-collection-button"
+            (click)="toggleCollection($index)"
+          >
+            @if (!emoji.url) {
+              {{ emoji.id }}
+            }
+            <img
+              *ngIf="emoji.url"
+              loading="lazy"
+              class="mr-2 ml-2"
+              [src]="baseMediaUrl + emoji.url"
+              [alt]="emojiCollection.name"
+              [title]="emojiCollection.name"
+            />
+          </button>
+        }
+      </div>
+      <hr />
     </div>
-    <hr />
 
-    <cdk-virtual-scroll-viewport itemSize="50" class="emoji-viewport" minBufferPx="400" maxBufferPx="500">
-      <div *cdkVirtualFor="let row of this.emojiRenderable()" class="emoji-row" [class.emoji-header]="row.tag === 0">
-        @if (row.tag === 0) {
+    <cdk-virtual-scroll-viewport
+      itemSize="55"
+      class="emoji-viewport"
+      minBufferPx="200"
+      maxBufferPx="300"
+      [style.height.px]="this.virtualHeight()"
+    >
+      <div *cdkVirtualFor="let row of this.vcRows()" class="emoji-row" [class.emoji-header]="row.tag === 0">
+        @if (row.tag == 0) {
           <span>{{ row.name }}</span>
         } @else {
-          @for (emoji of row.emos; track $index) {
-            <button
-              mat-flat-button
-              [title]="emoji.name"
-              (click)="click(emoji)"
-              class="p-2 flex align-content-center justify-content-center cursor-pointer bg-transparent emoji-item"
-            >
-              @if (!emoji.url) {
-                {{ emoji.id }}
-              } @else {
-                <img
-                  loading="lazy"
-                  class="post-emoji-preview mr-2 ml-2"
-                  [src]="baseMediaUrl + emoji.url"
-                  [alt]="emoji.name"
-                />
-              }
-            </button>
+          @for (e of this.rowIterable(); track $index) {
+            @if (row.index + $index < row.array.length) {
+              @let emoji = row.array[row.index + $index];
+              <button
+                mat-flat-button
+                [title]="emoji.name"
+                (click)="click(emoji)"
+                class="flex align-content-center justify-content-center cursor-pointer bg-transparent emoji-item"
+              >
+                @if (!emoji.url) {
+                  {{ emoji.id }}
+                } @else {
+                  <img
+                    class="post-emoji-preview"
+                    loading="lazy"
+                    [alt]="emoji.name"
+                    [src]="this.baseMediaUrl + emoji.url"
+                  />
+                }
+              </button>
+            }
           }
         }
       </div>

--- a/packages/frontend/src/app/components/emoji-collections/emoji-collections.component.scss
+++ b/packages/frontend/src/app/components/emoji-collections/emoji-collections.component.scss
@@ -5,11 +5,9 @@ $narrow: 800px;
   height: 32px;
 }
 
-.emoji-position {
-  position: relative !important;
-}
-
 .emoji-container {
+  height: 100%;
+  justify-content: space-between;
   display: flex;
   flex-direction: row;
   @media (max-width: $narrow) {
@@ -28,12 +26,13 @@ $narrow: 800px;
   display: flex;
   flex-direction: column;
   row-gap: 5px;
+  padding-bottom: 500px;
 }
 
 .emoji-header {
   text-align: left;
   justify-content: end !important;
-  align-items:center;
+  align-items: center;
   padding-left: 1em;
   padding-right: 1em;
 }
@@ -68,6 +67,12 @@ $narrow: 800px;
     height: 64px;
     overflow-y: hidden;
     overflow-x: scroll;
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background-color: var(--mat-sys-surface);
+    z-index: 99;
   }
 }
 .emoji-sidebar-child {
@@ -86,9 +91,12 @@ $narrow: 800px;
   display: flex;
   flex-direction: column;
   justify-content: center;
-  align-items: center;margin: auto;
+  align-items: center;
+  margin: auto;
 
-  span {
-    line-height:40px;
+  span,
+  img {
+    width: 25px;
+    height: 25px;
   }
 }

--- a/packages/frontend/src/app/components/emoji-picker/emoji-picker.component.scss
+++ b/packages/frontend/src/app/components/emoji-picker/emoji-picker.component.scss
@@ -5,6 +5,11 @@ $narrow: 800px;
   justify-content: space-between;
 }
 
+.emojireact-overlay {
+  height: 100%;
+  overflow: hidden;
+  overscroll-behavior: contain;
+}
 :host {
   width: 50vw;
   display: block;
@@ -16,6 +21,7 @@ $narrow: 800px;
   box-shadow: var(--mat-sys-level3);
   overscroll-behavior: contain;
   @media (max-width: $narrow) {
-    width: 100%;
+    width: 100vw;
+    height: 100vh;
   }
 }

--- a/packages/frontend/src/app/components/emoji-react/emoji-react.component.scss
+++ b/packages/frontend/src/app/components/emoji-react/emoji-react.component.scss
@@ -6,19 +6,3 @@ button {
 }
 
 
-.emojireact-overlay {
-  overflow-x: hidden;
-  overflow-y: auto;
-  background-color: var(--mat-sys-surface-container-high);
-  border-radius: var(--mat-sys-corner-small);
-  box-shadow: var(--mat-sys-level3);
-  overscroll-behavior: contain;
-  z-index: 9999
-}
-
-.emoji-away {
-  position: fixed;
-  inset: 0 0 0 0;
-  background-color: rgba(0, 0, 0, 0.3);
-  z-index: 999
-}


### PR DESCRIPTION
A couple of changes to the look and (hopefully!) performance of the emoji picker:
- Go fullscreen on narrow screens
  - Mainly to account for phone keyboard and increase selection height
- Don't show headers of empty collections
- Switch to a custom iterator implementation to avoid having to group emojis into rows prior to templating

<details>
<summary> New look on mobile: </summary>

![image](https://github.com/user-attachments/assets/08a90523-8857-4909-8999-6e7f88fcc844)

</details>