### PR TITLE
Make the docker compose script safer

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -103,7 +103,7 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DBNAME}
     volumes:
-      - dbpg:/var/lib/postgresql
+      - dbpg:/var/lib/postgresql/data
 
   adminer:
     image: adminer
@@ -112,6 +112,8 @@ services:
   redis:
     image: redis:7.2.4
     restart: unless-stopped
+    volumes:
+      - redis:/data
 
   pds:
     image: ghcr.io/bluesky-social/pds:0.4
@@ -143,3 +145,4 @@ volumes:
   caddy:
   pds:
   frontend:
+  redis:


### PR DESCRIPTION
Due to a typo in the database volume mounts the database files have been added to an anonymous volume instead of a named one. This means if anyone is restarting the app using `docker compose down && docker compose up` they would get a new anonymous instance and seemingly nuke their database

This fixes to make sure that the named volume is mounted in the proper place.

However this will also seemingly cause the bug for anyone updating to this instance, so we might want to do some warning or no idea for those couple peoples who already using the compose scripts