### PR TITLE
Add support for exporting users to ActivityPub backup

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The "main" wafrn app is located at [app.wafrn.net](https://app.wafrn.net).
 
 * [Development documentation](./docs/development.md)
 * [Deployment documentation](./docs/deployment.md)
+* [Wafrn Management](./docs/management.md)
 * [Importing external backups](./docs/import.md)
 
 If you need support you can also always find the latest Discord invite [on our website](https://wafrn.net)

--- a/docker-compose.simple.metrics.yml
+++ b/docker-compose.simple.metrics.yml
@@ -31,7 +31,7 @@ services:
         ENABLE_BSKY: ${ENABLE_BSKY}
         PDS_DOMAIN_NAME: ${PDS_DOMAIN_NAME}
 
-        USE_WORKERS: ${USE_WORKERS}
+        USE_WORKERS: true
         LOG_SQL_QUERIES: ${LOG_SQL_QUERIES:-}
         UPLOAD_LIMIT: ${UPLOAD_LIMIT:-}
         POSTS_PER_PAGE: ${POSTS_PER_PAGE:-}

--- a/docker-compose.simple.yml
+++ b/docker-compose.simple.yml
@@ -31,7 +31,7 @@ services:
         ENABLE_BSKY: ${ENABLE_BSKY}
         PDS_DOMAIN_NAME: ${PDS_DOMAIN_NAME}
 
-        USE_WORKERS: ${USE_WORKERS}
+        USE_WORKERS: true
         LOG_SQL_QUERIES: ${LOG_SQL_QUERIES:-}
         UPLOAD_LIMIT: ${UPLOAD_LIMIT:-}
         POSTS_PER_PAGE: ${POSTS_PER_PAGE:-}

--- a/docs/import.md
+++ b/docs/import.md
@@ -4,20 +4,20 @@ If you are running a self-hosted instance (or if the instance owner allows you) 
 
 ## Importing ActivityPub backups
 
-You can import backups in the ActivityPub backup format, for example the ones that you can obtain from Mastodon's export function. The import will only import the posts and the attached media files from the backup. It will not import neither your blog settings, nor your likes. The import will also try to import the entire conversation chain of your posts - given those posts still exist in their original location. The backups usually don't contain these resources, so if these are gone from the internet then these threads will be incomplete.
+You can import backups in the ActivityPub backup format, for example the ones that you can obtain from Mastodon's export function. The import will only import the posts and the attached media files from the backup. It will not import your blog settings. The import will also try to import the entire conversation chain of your posts - given those posts still exist in their original location. The backups usually don't contain these resources, so if these are gone from the internet then these threads will be incomplete. When importing a backup created using Wafrn, and the all-inclusive option is chosen the import will import them from the backup file instead of obtaining them fresh from the internet however.
 
 To import follow the steps:
 
 1. You need to create the user on the instance that will hold the posts. The importer will not change this user, so you'll have to manually set up the avatar, headers, and description.
 
-2. Start up the backend. The workers need to be running during import, otherwise the import will hang.
+2. Start up the backend. The workers need to be running during import, otherwise the import will hang. When importing data containing Bluesky threads you'll also need to have the Bluesky integration running.
 
 3. Run the following command:
 
 ```sh
 cp <filename.zip> packages/backend/uploads
 docker exec -ti wafrn-backend-1 npm exec tsx utils/maintenanceTasks/importActivityPubBackup.ts uploads/<filename.zip> <local_username>
-rm packages/backend/uploads/archive.zip
+rm packages/backend/uploads/<filename.zip>
 ```
 
 for example if your backup is called `archive.zip` and the user you created locally is `awesomeuser`:

--- a/docs/import.md
+++ b/docs/import.md
@@ -15,14 +15,17 @@ To import follow the steps:
 3. Run the following command:
 
 ```sh
-cd packages/backend
-npm exec tsx utils/maintenanceTasks/importActivityPubBackup.ts <filename.zip> <local_username>
+cp <filename.zip> packages/backend/uploads
+docker exec -ti wafrn-backend-1 npm exec tsx utils/maintenanceTasks/importActivityPubBackup.ts uploads/<filename.zip> <local_username>
+rm packages/backend/uploads/archive.zip
 ```
 
 for example if your backup is called `archive.zip` and the user you created locally is `awesomeuser`:
 
 ```sh
-npm exec tsx utils/maintenanceTasks/importActivityPubBackup.ts archive.zip awesomeuser
+cp archive.zip packages/backend/uploads
+docker exec -ti wafrn-backend-1 npm exec tsx utils/maintenanceTasks/importActivityPubBackup.ts uploads/archive.zip awesomeuser
+rm packages/backend/uploads/archive.zip
 ```
 
 ## Importing Tumblr backups

--- a/docs/management.md
+++ b/docs/management.md
@@ -1,0 +1,11 @@
+# Wafrn Management
+
+## Exporting / backing up users
+
+If any user asks you to backup their data, you can run the following command:
+
+```sh
+docker exec -ti wafrn-backend-1 npm exec tsx utils/maintenanceTasks/exportActivityPubBackup.ts <username>
+```
+
+Once export is finished this tool will write out a randomized URL to the console where the user can download their backup file. Once downloaded this file should be deleted manually from the server.

--- a/docs/management.md
+++ b/docs/management.md
@@ -2,10 +2,18 @@
 
 ## Exporting / backing up users
 
-If any user asks you to backup their data, you can run the following command:
+If any user asks you to backup their data, or you want to create a backup for yourself, you can run the following command:
 
 ```sh
-docker exec -ti wafrn-backend-1 npm exec tsx utils/maintenanceTasks/exportActivityPubBackup.ts <username>
+docker exec -ti wafrn-backend-1 npm exec tsx utils/maintenanceTasks/exportActivityPubBackup.ts <username> <exportType>
 ```
+
+The `exportType` can be one of the following:
+
+* `1`: *Basic:* Only export the named blog, and local media files attached to the main blog. Result will be mostly compatible with what Mastodon would export as a backup. This is the default
+* `2`: *Threaded:* Export the named blog, and all conversation information (post threads) related to the main blog. Also include all local media files for the blog and threads.
+* `3`: *All-inclusive:* Same as `2`, but also downloads all linked remote media files and includes them in the backup.
+
+> **Note:** Only the default option (`1`) will generate a backup file compatible with some Mastodon import tools, although if Bluesky is enabled it will also contain Bluesky posts that these importers might choke on. All options are supported by Wafrn's own importer however, including importing Bluesky data.
 
 Once export is finished this tool will write out a randomized URL to the console where the user can download their backup file. Once downloaded this file should be deleted manually from the server.

--- a/package-lock.json
+++ b/package-lock.json
@@ -4759,7 +4759,6 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^5.1.2",
@@ -4777,7 +4776,6 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
       "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -4790,14 +4788,12 @@
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@isaacs/cliui/node_modules/string-width": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eastasianwidth": "^0.2.0",
@@ -4815,7 +4811,6 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
       "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.1.0",
@@ -6802,7 +6797,6 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -7474,6 +7468,15 @@
       "integrity": "sha512-lh9515BNsvKSNvyUqbj5yFu83iIDQ77SwVcsN/SnEGawczhsKU6qWuogewN1GweTi5Imo5ToQ9s+nNTf97IXvg==",
       "license": "MIT"
     },
+    "node_modules/@types/archiver": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/archiver/-/archiver-6.0.3.tgz",
+      "integrity": "sha512-a6wUll6k3zX6qs5KlxIggs1P1JcYJaTCx2gnlr+f0S1yd2DoaEwoIK10HmBaLnZwWneBz+JBm0dwcZu0zECBcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/readdir-glob": "*"
+      }
+    },
     "node_modules/@types/argparse": {
       "version": "1.0.38",
       "resolved": "https://registry.npmjs.org/@types/argparse/-/argparse-1.0.38.tgz",
@@ -7851,6 +7854,15 @@
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
       "license": "MIT"
     },
+    "node_modules/@types/readdir-glob": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@types/readdir-glob/-/readdir-glob-1.1.5.tgz",
+      "integrity": "sha512-raiuEPUYqXu+nvtY2Pe8s8FEmZ3x5yAH4VkLdihcPdalvsHltomrRC9BzuStrJ9yk06470hS0Crw0f1pXqD+Hg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/retry": {
       "version": "0.12.2",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.2.tgz",
@@ -7989,6 +8001,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "license": "MIT"
     },
     "node_modules/@types/validator": {
       "version": "13.12.2",
@@ -8646,7 +8664,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
       "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -8694,6 +8711,202 @@
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
       "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
       "license": "ISC"
+    },
+    "node_modules/archiver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-7.0.1.tgz",
+      "integrity": "sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^5.0.2",
+        "async": "^3.2.4",
+        "buffer-crc32": "^1.0.0",
+        "readable-stream": "^4.0.0",
+        "readdir-glob": "^1.1.2",
+        "tar-stream": "^3.0.0",
+        "zip-stream": "^6.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/archiver-utils": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-5.0.2.tgz",
+      "integrity": "sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==",
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^10.0.0",
+        "graceful-fs": "^4.2.0",
+        "is-stream": "^2.0.1",
+        "lazystream": "^1.0.0",
+        "lodash": "^4.17.15",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/glob": {
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/archiver/node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
+    },
+    "node_modules/archiver/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/archiver/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/archiver/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
     },
     "node_modules/are-we-there-yet": {
       "version": "2.0.0",
@@ -8956,6 +9169,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/b4a": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.7.tgz",
+      "integrity": "sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==",
+      "license": "Apache-2.0"
+    },
     "node_modules/babel-jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
@@ -9159,6 +9378,13 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
+    },
+    "node_modules/bare-events": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.5.4.tgz",
+      "integrity": "sha512-+gFfDkR8pj4/TrWCGUGWmJIkBwuxPS5F+a5yWjOHQt2hHvNZd5YLzadjmDUtFmMM4y429bnKLa8bYBMHcYdnQA==",
+      "license": "Apache-2.0",
+      "optional": true
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -9466,6 +9692,15 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
+      "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/buffer-equal-constant-time": {
@@ -10242,6 +10477,83 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/compress-commons": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-6.0.2.tgz",
+      "integrity": "sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==",
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "crc32-stream": "^6.0.0",
+        "is-stream": "^2.0.1",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/compress-commons/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/compress-commons/node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/compress-commons/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/compress-commons/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/compressible": {
       "version": "2.0.18",
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
@@ -10572,6 +10884,80 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/crc32-stream": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-6.0.0.tgz",
+      "integrity": "sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==",
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/crc32-stream/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/crc32-stream/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/crc32-stream/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/create-jest": {
@@ -11128,7 +11514,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/ecc-jsbn": {
@@ -12096,6 +12481,12 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "license": "MIT"
+    },
     "node_modules/fast-glob": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
@@ -12437,7 +12828,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
       "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "cross-spawn": "^7.0.6",
@@ -14108,7 +14498,6 @@
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
       "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
@@ -15829,6 +16218,18 @@
         "shell-quote": "^1.8.1"
       }
     },
+    "node_modules/lazystream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+      "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.6.3"
+      }
+    },
     "node_modules/less": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/less/-/less-4.2.2.tgz",
@@ -16750,7 +17151,6 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -18116,7 +18516,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-      "dev": true,
       "license": "BlueOak-1.0.0"
     },
     "node_modules/pacote": {
@@ -18341,7 +18740,6 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
       "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^10.2.0",
@@ -18358,7 +18756,6 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/path-to-regexp": {
@@ -19468,6 +19865,36 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
+    },
+    "node_modules/readdir-glob": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
+      "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^5.1.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/readdirp": {
       "version": "4.1.2",
@@ -20819,7 +21246,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -21421,6 +21847,19 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/streamx": {
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.22.0.tgz",
+      "integrity": "sha512-sLh1evHOzBy/iWRiR6d1zRcLao4gGZr3C1kzNz4fopCOKJb6xD9ub8Mpi9Mr1R6id5o43S+d93fI48UC5uM9aw==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      },
+      "optionalDependencies": {
+        "bare-events": "^2.2.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -21502,7 +21941,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -21517,7 +21955,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -21527,14 +21964,12 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/string-width-cjs/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -21544,7 +21979,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -21557,7 +21991,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
       "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
@@ -21574,7 +22007,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -21587,7 +22019,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -21755,6 +22186,17 @@
         "node": ">=10"
       }
     },
+    "node_modules/tar-stream": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
     "node_modules/tar/node_modules/fs-minipass": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
@@ -21904,6 +22346,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
+      "integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
       }
     },
     "node_modules/text-table": {
@@ -23530,7 +23981,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -23548,7 +23998,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -23558,14 +24007,12 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/wrap-ansi-cjs/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -23575,7 +24022,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -23590,7 +24036,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -23841,6 +24286,69 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/zip-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-6.0.1.tgz",
+      "integrity": "sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==",
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^5.0.0",
+        "compress-commons": "^6.0.2",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/zip-stream/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/zip-stream/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/zip-stream/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/zod": {
       "version": "3.24.2",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
@@ -23871,6 +24379,7 @@
         "@rushstack/ts-command-line": "^5.0.0",
         "@skyware/firehose": "^0.3.2",
         "@skyware/jetstream": "^0.2.0",
+        "@types/archiver": "^6.0.3",
         "@types/bcrypt": "^5.0.0",
         "@types/body-parser": "^1.19.5",
         "@types/cors": "^2.8.12",
@@ -23887,10 +24396,12 @@
         "@types/swagger-ui-express": "^4.1.3",
         "@types/underscore": "^1.11.5",
         "@types/unzip-stream": "^0.3.4",
+        "@types/uuid": "^10.0.0",
         "@types/validator": "^13.12.0",
         "@types/web-push": "^3.6.4",
         "@typescript-eslint/eslint-plugin": "^5.9.0",
         "@typescript-eslint/parser": "^5.9.0",
+        "archiver": "^7.0.1",
         "atproto-firehose": "^0.2.2",
         "axios": "^1.8.2",
         "bcrypt": "^5.0.0",
@@ -23943,6 +24454,7 @@
         "umzug": "^3.8.2",
         "underscore": "^1.13.6",
         "unzip-stream": "^0.3.4",
+        "uuid": "^11.1.0",
         "web-push": "^3.6.7"
       },
       "devDependencies": {
@@ -24352,6 +24864,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/backend/node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "packages/frontend": {

--- a/packages/backend/models/post.ts
+++ b/packages/backend/models/post.ts
@@ -20,7 +20,7 @@ import { PostHostView } from "./postHostView.js";
 import { RemoteUserPostView } from "./remoteUserPostView.js";
 import { FederatedHost } from "./federatedHost.js";
 import { PostAncestor } from "./postAncestor.js";
-import { BelongsToManyGetAssociationsMixin, BelongsToManySetAssociationsMixin, BelongsToSetAssociationMixin, HasManyGetAssociationsMixin, HasManyRemoveAssociationMixin, HasManyRemoveAssociationsMixin, HasManySetAssociationsMixin, HasOneGetAssociationMixin } from "sequelize";
+import { BelongsToGetAssociationMixin, BelongsToManyGetAssociationsMixin, BelongsToManySetAssociationsMixin, BelongsToSetAssociationMixin, HasManyGetAssociationsMixin, HasManyRemoveAssociationMixin, HasManyRemoveAssociationsMixin, HasManySetAssociationsMixin, HasOneGetAssociationMixin } from "sequelize";
 
 export const Privacy = {
   Public: 0,
@@ -157,6 +157,7 @@ export class Post extends Model<PostAttributes, PostAttributes> implements PostA
 
   @BelongsTo(() => Post, "parentId")
   declare parent: Post
+  declare getParent: BelongsToGetAssociationMixin<Post>
   declare setParent: BelongsToSetAssociationMixin<Post, string>
 
   @HasMany(() => Post, "parentId")
@@ -228,7 +229,8 @@ export class Post extends Model<PostAttributes, PostAttributes> implements PostA
   declare getPostTags: HasManyGetAssociationsMixin<PostTag>
 
   @BelongsTo(() => User)
-  declare user: User;
+  declare user: User
+  declare getUser: BelongsToGetAssociationMixin<User>
 
   @HasMany(() => Media, {
     sourceKey: "id"

--- a/packages/backend/models/user.ts
+++ b/packages/backend/models/user.ts
@@ -28,6 +28,7 @@ import {
   BelongsToManyRemoveAssociationMixin,
   BelongsToManyRemoveAssociationsMixin,
   BelongsToManySetAssociationsMixin,
+  HasManyGetAssociationsMixin,
   HasManyRemoveAssociationMixin
 } from 'sequelize'
 import { Col } from 'sequelize/lib/utils'
@@ -463,6 +464,7 @@ export class User extends Model<UserAttributes, UserAttributes> implements UserA
     sourceKey: 'id'
   })
   declare posts: Post[]
+  declare getPosts: HasManyGetAssociationsMixin<Post>
 
   @HasMany(() => Media, {
     sourceKey: 'id'
@@ -481,11 +483,13 @@ export class User extends Model<UserAttributes, UserAttributes> implements UserA
     sourceKey: 'id'
   })
   declare userLikesPostRelations: UserLikesPostRelations[]
+  declare getUserLikesPostRelations: HasManyGetAssociationsMixin<UserLikesPostRelations>
 
   @HasMany(() => UserBookmarkedPosts, {
     sourceKey: 'id'
   })
   declare userBookmarkedPosts: UserBookmarkedPosts[]
+  declare getUserBookmarkedPosts: HasManyGetAssociationsMixin<UserBookmarkedPosts>
 
   @HasMany(() => RemoteUserPostView, {
     sourceKey: 'id'

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -28,6 +28,7 @@
     "@rushstack/ts-command-line": "^5.0.0",
     "@skyware/firehose": "^0.3.2",
     "@skyware/jetstream": "^0.2.0",
+    "@types/archiver": "^6.0.3",
     "@types/bcrypt": "^5.0.0",
     "@types/body-parser": "^1.19.5",
     "@types/cors": "^2.8.12",
@@ -44,10 +45,12 @@
     "@types/swagger-ui-express": "^4.1.3",
     "@types/underscore": "^1.11.5",
     "@types/unzip-stream": "^0.3.4",
+    "@types/uuid": "^10.0.0",
     "@types/validator": "^13.12.0",
     "@types/web-push": "^3.6.4",
     "@typescript-eslint/eslint-plugin": "^5.9.0",
     "@typescript-eslint/parser": "^5.9.0",
+    "archiver": "^7.0.1",
     "atproto-firehose": "^0.2.2",
     "axios": "^1.8.2",
     "bcrypt": "^5.0.0",
@@ -100,6 +103,7 @@
     "umzug": "^3.8.2",
     "underscore": "^1.13.6",
     "unzip-stream": "^0.3.4",
+    "uuid": "^11.1.0",
     "web-push": "^3.6.7"
   },
   "devDependencies": {

--- a/packages/backend/utils/activitypub/postToJSONLD.ts
+++ b/packages/backend/utils/activitypub/postToJSONLD.ts
@@ -86,11 +86,9 @@ async function postToJSONLD(postId: string): Promise<activityPubObject | undefin
   // we remove the wafrnmedia from the post for the outside world, as they get this on the attachments
   processedContent = processedContent.replaceAll(wafrnMediaRegex, '')
   if (ask) {
-    processedContent = `<p>${getUserName(userAsker)} asked </p> <blockquote>${
-      ask.question
-    }</blockquote> ${processedContent} <p>To properly see this ask, <a href="${
-      environment.frontendUrl + '/fediverse/post/' + post.id
-    }">check the post in the original instance</a></p>`
+    processedContent = `<p>${getUserName(userAsker)} asked </p> <blockquote>${ask.question
+      }</blockquote> ${processedContent} <p>To properly see this ask, <a href="${environment.frontendUrl + '/fediverse/post/' + post.id
+      }">check the post in the original instance</a></p>`
   }
   const mentions: string[] = post.mentionPost.map((elem: any) => elem.id)
   const fediMentions: fediverseTag[] = []
@@ -200,13 +198,13 @@ async function postToJSONLD(postId: string): Promise<activityPubObject | undefin
       // conversation: conversationString,
       content: (processedContent + tagsAndQuotes).replace(lineBreaksAtEndRegex, ''),
       attachment: postMedias
-        ?.sort((a: any, b: any) => a.mediaOrder - b.mediaOrder)
-        .map((media: any) => {
+        ?.sort((a: Media, b: Media) => a.mediaOrder - b.mediaOrder)
+        .map((media: Media) => {
           const extension = media.url.split('.')[media.url.split('.').length - 1].toLowerCase()
           return {
             type: 'Document',
             mediaType: media.mediaType,
-            url: environment.mediaUrl + media.url,
+            url: media.external ? media.url : environment.mediaUrl + media.url,
             sensitive: media.NSFW ? true : false,
             name: media.description
           }
@@ -249,8 +247,8 @@ async function postToJSONLD(postId: string): Promise<activityPubObject | undefin
         post.privacy / 1 === Privacy.DirectMessage
           ? mentionedUsers
           : post.privacy / 1 === Privacy.Public
-          ? ['https://www.w3.org/ns/activitystreams#Public']
-          : [stringMyFollowers],
+            ? ['https://www.w3.org/ns/activitystreams#Public']
+            : [stringMyFollowers],
       cc: [`${environment.frontendUrl}/fediverse/blog/${localUser.url.toLowerCase()}`, stringMyFollowers],
       object: parentPostString
     }
@@ -283,7 +281,7 @@ function getToAndCC(
       break
     }
     default: {
-      ;(to = mentionedUsers), (cc = [])
+      ; (to = mentionedUsers), (cc = [])
     }
   }
   return {

--- a/packages/backend/utils/activitypub/processors/announce.ts
+++ b/packages/backend/utils/activitypub/processors/announce.ts
@@ -16,7 +16,7 @@ async function AnnounceActivity(body: activityPubObject, remoteUser: User, user:
     }
   })
   if (existingPost) {
-    return
+    return existingPost
   }
   // LEMMY HACK
   let urlToGet =

--- a/packages/backend/utils/activitypub/processors/announce.ts
+++ b/packages/backend/utils/activitypub/processors/announce.ts
@@ -23,8 +23,8 @@ async function AnnounceActivity(body: activityPubObject, remoteUser: User, user:
     typeof apObject.object === 'string'
       ? apObject.object
       : apObject.object.object
-      ? apObject.object.object
-      : apObject.id
+        ? apObject.object.object
+        : apObject.id
   urlToGet = typeof urlToGet === 'string' ? urlToGet : urlToGet?.id
   if (!urlToGet) {
     const error = new Error()
@@ -45,12 +45,20 @@ async function AnnounceActivity(body: activityPubObject, remoteUser: User, user:
 
   const privacy = getApObjectPrivacy(apObject, remoteUser)
   if (remoteUser.url !== environment.deletedUser && retooted_content) {
+    let createdAt = new Date()
+    if (apObject.published)
+      createdAt = new Date(apObject.published)
+
+    if (createdAt.getTime() > new Date().getTime()) {
+      createdAt = new Date()
+    }
+
     const postToCreate = {
       content: '',
       isReblog: true,
       content_warning: '',
-      createdAt: new Date(),
-      updatedAt: new Date(),
+      createdAt: createdAt,
+      updatedAt: createdAt,
       userId: remoteUser.id,
       remotePostId: body.id,
       privacy: privacy,
@@ -70,6 +78,8 @@ async function AnnounceActivity(body: activityPubObject, remoteUser: User, user:
         userUrl: remoteUser.url
       }
     )
+
+    return newToot;
     // await signAndAccept({ body: body }, remoteUser, user)
   }
 }

--- a/packages/backend/utils/activitypub/userToJSONLD.ts
+++ b/packages/backend/utils/activitypub/userToJSONLD.ts
@@ -1,0 +1,99 @@
+import { environment } from "../../environment.js"
+import { User } from "../../models/index.js"
+import { getUserEmojis } from "../cacheGetters/getUserEmojis.js"
+import { getUserOptions } from "../cacheGetters/getUserOptions.js"
+import { logger } from "../logger.js"
+import { redisCache } from "../redis.js"
+import { emojiToAPTag } from "./emojiToAPTag.js"
+
+export async function userToJSONLD(user: User) {
+  const userCacheResult = await redisCache.get('fediverse:user:base:' + user.id)
+  let userForFediverse
+  if (userCacheResult) {
+    userForFediverse = JSON.parse(userCacheResult)
+  } else {
+    const emojis = await getUserEmojis(user.id)
+    const userOptions = await getUserOptions(user.id)
+    let unprocessedAttachments = userOptions.find((elem) => elem.optionName === 'fediverse.public.attachment')
+    let alsoKnownAs: any[] = []
+    let alsoKnownAsList = userOptions.find((elem) => elem.optionName === 'fediverse.public.alsoKnownAs')
+    if (alsoKnownAsList?.optionValue) {
+      try {
+        const parsedValue = JSON.parse(alsoKnownAsList?.optionValue)
+        if (typeof parsedValue === 'string') {
+          for (let elem of parsedValue.split(',')) {
+            let url = new URL(elem)
+            alsoKnownAs.push(url.toString())
+          }
+        }
+      } catch (_) { }
+    }
+    if (user.bskyDid) {
+      alsoKnownAs.push(`at://${user.bskyDid}`)
+    }
+    let attachments: { type: string; name: string; value: string }[] = []
+    if (unprocessedAttachments) {
+      try {
+        const attachmentsArray: { name: string; value: string }[] = JSON.parse(
+          unprocessedAttachments.optionValue
+        )
+        attachments = attachmentsArray.map((elem) => {
+          return { ...elem, type: 'PropertyValue' }
+        })
+      } catch (error) {
+        logger.debug({
+          message: `Error parsing attachment for user ${user.url}`,
+          error: error
+        })
+      }
+    }
+    userForFediverse = {
+      '@context': ['https://www.w3.org/ns/activitystreams', 'https://w3id.org/security/v1'],
+      id: `${environment.frontendUrl}/fediverse/blog/${user.url.toLowerCase()}`,
+      type: 'Person',
+      attachment: attachments,
+      following: `${environment.frontendUrl}/fediverse/blog/${user.url.toLowerCase()}/following`,
+      followers: `${environment.frontendUrl}/fediverse/blog/${user.url.toLowerCase()}/followers`,
+      featured: `${environment.frontendUrl}/fediverse/blog/${user.url.toLowerCase()}/featured`,
+      inbox: `${environment.frontendUrl}/fediverse/blog/${user.url.toLowerCase()}/inbox`,
+      outbox: `${environment.frontendUrl}/fediverse/blog/${user.url.toLowerCase()}/outbox`,
+      preferredUsername: user.url.toLowerCase(),
+      name: user.name,
+      summary: user.description,
+      url: `${environment.frontendUrl}/fediverse/blog/${user.url.toLowerCase()}`,
+      manuallyApprovesFollowers: user.manuallyAcceptsFollows,
+      discoverable: true,
+      alsoKnownAs: alsoKnownAs,
+      published: user.createdAt,
+      tag: emojis.map((emoji: any) => emojiToAPTag(emoji)),
+      endpoints: {
+        sharedInbox: `${environment.frontendUrl}/fediverse/sharedInbox`
+      },
+      ...(user.avatar
+        ? {
+          icon: {
+            type: 'Image',
+            mediaType: 'image/webp',
+            url: environment.mediaUrl + user.avatar
+          }
+        }
+        : undefined),
+      ...(user.headerImage
+        ? {
+          image: {
+            type: 'Image',
+            mediaType: 'image/webp',
+            url: environment.mediaUrl + user.headerImage
+          }
+        }
+        : undefined),
+      publicKey: {
+        id: `${environment.frontendUrl}/fediverse/blog/${user.url.toLowerCase()}#main-key`,
+        owner: `${environment.frontendUrl}/fediverse/blog/${user.url.toLowerCase()}`,
+        publicKeyPem: user.publicKey
+      }
+    }
+    redisCache.set('fediverse:user:base:' + user.id, JSON.stringify(userForFediverse), 'EX', 300)
+  }
+  return userForFediverse;
+}

--- a/packages/backend/utils/maintenanceTasks/exportActivityPubBackup.ts
+++ b/packages/backend/utils/maintenanceTasks/exportActivityPubBackup.ts
@@ -1,0 +1,186 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// exports a user into an ActivityPub compatible backup file.
+
+import fs from "fs";
+import { Post, User } from "../../models/index.js";
+import { userToJSONLD } from "../activitypub/userToJSONLD.js";
+import archiver from "archiver";
+import { v4 as uuidv4 } from 'uuid';
+import { environment } from "../../environment.js";
+import { postToJSONLD } from "../activitypub/postToJSONLD.js";
+
+const archived: Record<string, boolean> = {};
+
+async function extractImages(archive: archiver.Archiver, data: any) {
+  const promises: Promise<any>[] = [];
+  if (Array.isArray(data)) {
+    for (const value of data) {
+      promises.push(extractImages(archive, value));
+    }
+  } else if (typeof data === 'object') {
+    for (const key in data) {
+      const value = data[key];
+      if (key == 'url' && typeof value === 'string' && value.startsWith(environment.mediaUrl)) {
+        const fileName = value.slice(environment.mediaUrl.length + 1);
+        const newFileName = `media_attachments/files/${fileName}`;
+        if (!archived[fileName]) {
+          console.log(`Media file ${fileName}`);
+          archived[fileName] = true;
+          archive.file(`uploads/${fileName}`, { name: newFileName });
+        }
+        data[key] = `/${newFileName}`;
+      } else {
+        promises.push(extractImages(archive, value));
+      }
+    }
+  }
+  return Promise.all(promises);
+}
+
+async function exportBackup(userUrl: string): Promise<string> {
+  return new Promise(async (resolve, reject) => {
+    const user = await User.findOne({ where: { url: userUrl } });
+    if (!user)
+      return;
+
+    const fileName = `backup-${userUrl}-${Date.now()}-${uuidv4()}.zip`;
+    const output = fs.createWriteStream('uploads/' + fileName);
+
+    const archive = archiver('zip', { zlib: { level: 9 } });
+
+    output.on('close', () => {
+      resolve(fileName);
+    });
+
+    archive.on('error', (err: Error) => {
+      reject(err);
+    });
+
+    archive.pipe(output);
+
+    // Export Blog
+    const userData = await userToJSONLD(user);
+    await extractImages(archive, userData);
+    archive.append(JSON.stringify(userData), { name: 'actor.json' });
+
+    // Export Posts
+    const outbox: any = {};
+    outbox["@context"] = [
+      "https://www.w3.org/ns/activitystreams",
+      "https://w3id.org/security/v1",
+      {
+        "manuallyApprovesFollowers": "as:manuallyApprovesFollowers",
+        "sensitive": "as:sensitive",
+        "Hashtag": "as:Hashtag",
+        "movedTo": {
+          "@id": "as:movedTo",
+          "@type": "@id"
+        },
+        "alsoKnownAs": {
+          "@id": "as:alsoKnownAs",
+          "@type": "@id"
+        },
+        "toot": "http://joinmastodon.org/ns#",
+        "Emoji": "toot:Emoji",
+        "featured": {
+          "@id": "toot:featured",
+          "@type": "@id"
+        },
+        "featuredTags": {
+          "@id": "toot:featuredTags",
+          "@type": "@id"
+        },
+        "schema": "http://schema.org#",
+        "PropertyValue": "schema:PropertyValue",
+        "value": "schema:value",
+        "ostatus": "http://ostatus.org#",
+        "atomUri": "ostatus:atomUri",
+        "inReplyToAtomUri": "ostatus:inReplyToAtomUri",
+        "conversation": "ostatus:conversation",
+        "focalPoint": {
+          "@container": "@list",
+          "@id": "toot:focalPoint"
+        },
+        "blurhash": "toot:blurhash",
+        "discoverable": "toot:discoverable",
+        "indexable": "toot:indexable",
+        "memorial": "toot:memorial",
+        "votersCount": "toot:votersCount",
+        "suspended": "toot:suspended",
+        "attributionDomains": {
+          "@id": "toot:attributionDomains",
+          "@type": "@id"
+        },
+        "gts": "https://gotosocial.org/ns#",
+        "interactionPolicy": {
+          "@id": "gts:interactionPolicy",
+          "@type": "@id"
+        },
+        "canQuote": {
+          "@id": "gts:canQuote",
+          "@type": "@id"
+        },
+        "automaticApproval": {
+          "@id": "gts:automaticApproval",
+          "@type": "@id"
+        },
+        "manualApproval": {
+          "@id": "gts:manualApproval",
+          "@type": "@id"
+        }
+      }
+    ];
+    outbox.id = "outbox.json";
+    outbox.type = "OrderedCollection";
+    outbox.orderedItems = [];
+    for (const post of await user.getPosts({ order: [["createdAt", "ASC"]] })) {
+      console.log(`Processing ${post.id}`);
+      const postData = await postToJSONLD(post.id);
+      if (postData) {
+        await extractImages(archive, postData);
+        outbox.orderedItems.push(postData);
+        delete outbox.orderedItems[outbox.orderedItems.length - 1]["@context"];
+      }
+    }
+    outbox.totalItems = outbox.orderedItems.length;
+    archive.append(JSON.stringify(outbox), { name: 'outbox.json' });
+
+    // Export Likes
+
+    const likes: any = { "@context": "https://www.w3.org/ns/activitystreams", "id": "likes.json", "type": "OrderedCollection", "orderedItems": [] }
+
+    for (const like of await user.getUserLikesPostRelations({ include: Post })) {
+      if (like.post) {
+        const postRemoteId = like.post?.remotePostId || `${environment.frontendUrl}/fediverse/post/${like.post?.id}`;
+        likes.orderedItems.push(postRemoteId);
+      }
+    }
+
+    archive.append(JSON.stringify(likes), { name: 'likes.json' });
+
+    // Export Bookmarks
+
+    const bookmarks: any = { "@context": "https://www.w3.org/ns/activitystreams", "id": "bookmarks.json", "type": "OrderedCollection", "orderedItems": [] }
+
+    for (const bookmark of await user.getUserBookmarkedPosts({ include: Post })) {
+      if (bookmark.post) {
+        const postRemoteId = bookmark.post?.remotePostId || `${environment.frontendUrl}/fediverse/post/${bookmark.post?.id}`;
+        bookmarks.orderedItems.push(postRemoteId);
+      }
+    }
+
+    archive.append(JSON.stringify(bookmarks), { name: 'bookmarks.json' });
+
+    archive.finalize();
+  });
+}
+
+if (!process.argv[2]) {
+  console.log("Usage: tsx exportActivityPubBackup.ts <localUserName>");
+  process.exit(0);
+}
+
+const fileName = await exportBackup(process.argv[2]);
+
+console.log(`Exported to: ${environment.mediaUrl}/${fileName}`);
+process.exit(0);


### PR DESCRIPTION
Adds support to export a user to an ActivityPub style backup. Resulting file is compatible with the import script, which should import the posts, likes and bookmarks. Note that although the blog's data will be exported, the importer will still disregard it, that needs to be set up manually

There are three options to do an export, from only including the user's posts and media, to also including the entire threads, and potentially remote media as well. Export is done through the command line, but will put the resulting file to the media server so the user can be emailed manually about their backup. Cleanup of old backup files should be done manually though. UI can be built later by someone who is better at building UIs

Main change to core backend code is the extraction of the `user->JSONLD` code from the route into a separate helper so it can be called from multiple places. There are also two additions to the `getRemoteActor` and `getPostThreadRecursive` functions to allow importing of data from Bluesky if needed.