### PR TITLE
Fix security issues related to signature validation

### DIFF
--- a/packages/backend/routes/activitypub/activitypub.ts
+++ b/packages/backend/routes/activitypub/activitypub.ts
@@ -4,7 +4,7 @@ import {
   Emoji,
   sequelize
 } from '../../models/index.js'
-import { getCheckFediverseSignatureFucnction } from '../../utils/activitypub/checkFediverseSignature.js'
+import { getCheckFediverseSignatureFunction } from '../../utils/activitypub/checkFediverseSignature.js'
 import { environment } from '../../environment.js'
 import { return404 } from '../../utils/return404.js'
 import { Queue } from 'bullmq'
@@ -54,7 +54,7 @@ function activityPubRoutes(app: Application) {
   // Get blog for fediverse
   app.get(
     '/fediverse/blog/:url',
-    getCheckFediverseSignatureFucnction(false),
+    getCheckFediverseSignatureFunction(false),
     async (req: SignedRequest, res: Response) => {
       const url = req.params.url.toLowerCase()
       if (req.headers['accept']?.includes('*')) {
@@ -90,7 +90,7 @@ function activityPubRoutes(app: Application) {
 
   app.get(
     '/fediverse/blog/:url/following',
-    getCheckFediverseSignatureFucnction(false),
+    getCheckFediverseSignatureFunction(false),
     async (req: SignedRequest, res: Response) => {
       if (req.params?.url) {
         const url = req.params.url.toLowerCase()
@@ -151,7 +151,7 @@ function activityPubRoutes(app: Application) {
 
   app.get(
     '/fediverse/blog/:url/followers',
-    getCheckFediverseSignatureFucnction(false),
+    getCheckFediverseSignatureFunction(false),
     async (req: SignedRequest, res: Response) => {
       if (req.params?.url) {
         const url = req.params.url.toLowerCase()
@@ -213,7 +213,7 @@ function activityPubRoutes(app: Application) {
 
   app.get(
     '/fediverse/blog/:url/featured',
-    getCheckFediverseSignatureFucnction(true),
+    getCheckFediverseSignatureFunction(true),
     async (req: SignedRequest, res: Response) => {
       if (req.params?.url) {
         const url = req.params.url.toLowerCase()
@@ -250,7 +250,7 @@ function activityPubRoutes(app: Application) {
   // HERE is where the meat and potatoes are. This endpoint is what we use to recive stuff
   app.post(
     ['/fediverse/blog/:url/inbox', '/fediverse/sharedInbox'],
-    getCheckFediverseSignatureFucnction(true),
+    getCheckFediverseSignatureFunction(true),
     async (req: SignedRequest, res: Response) => {
       const urlToSearch = req.params?.url ? req.params.url : environment.adminUser
       const url = urlToSearch.toLowerCase()
@@ -275,7 +275,7 @@ function activityPubRoutes(app: Application) {
 
   app.get(
     '/fediverse/blog/:url/outbox',
-    getCheckFediverseSignatureFucnction(false),
+    getCheckFediverseSignatureFunction(false),
     async (req: SignedRequest, res: Response) => {
       if (req.params?.url) {
         const url = req.params.url.toLowerCase()

--- a/packages/backend/routes/frontend.ts
+++ b/packages/backend/routes/frontend.ts
@@ -5,11 +5,9 @@ import { Media, Post, User, sequelize } from '../models/index.js'
 import fs from 'fs'
 import dompurify from 'isomorphic-dompurify'
 import { redisCache } from '../utils/redis.js'
-import { logger } from '../utils/logger.js'
-import { getCheckFediverseSignatureFucnction } from '../utils/activitypub/checkFediverseSignature.js'
+import { getCheckFediverseSignatureFunction } from '../utils/activitypub/checkFediverseSignature.js'
 import { SignedRequest } from '../interfaces/fediverse/signedRequest.js'
 import { handlePostRequest } from '../utils/activitypub/handlePostRequest.js'
-import { getUserOptions } from '../utils/cacheGetters/getUserOptions.js'
 import { Privacy } from '../models/post.js'
 
 const cacheOptions = {
@@ -39,7 +37,7 @@ function frontend(app: Application) {
     }
   )
 
-  app.get('/post/:id', getCheckFediverseSignatureFucnction(false), async function (req: SignedRequest, res) {
+  app.get('/post/:id', getCheckFediverseSignatureFunction(false), async function (req: SignedRequest, res) {
     //res.redirect(`/fediverse${req.url}`)
     res.send(
       `<script>
@@ -93,7 +91,7 @@ function frontend(app: Application) {
 
   app.get(
     ['/fediverse/post/:id', '/fediverse/activity/post/:id'],
-    getCheckFediverseSignatureFucnction(false),
+    getCheckFediverseSignatureFunction(false),
     async (req: SignedRequest, res: Response) => {
       if (req.fediData?.valid) {
         await handlePostRequest(req, res)

--- a/packages/backend/utils/cacheGetters/getUserIdFromRemoteId.ts
+++ b/packages/backend/utils/cacheGetters/getUserIdFromRemoteId.ts
@@ -1,4 +1,4 @@
-import { User, sequelize } from '../../models/index.js'
+import { User } from '../../models/index.js'
 import { environment } from '../../environment.js'
 import { redisCache } from '../redis.js'
 

--- a/packages/backend/utils/overrideContentType.ts
+++ b/packages/backend/utils/overrideContentType.ts
@@ -4,6 +4,7 @@ import { logger } from './logger.js'
 export default function overrideContentType(req: Request, res: Response, next: NextFunction) {
   const UrlPath = req.path
   if (UrlPath.startsWith('/fediverse')) {
+    req.headers['orig-content-type'] = req.headers['content-type']
     req.headers['content-type'] = 'application/json;charset=UTF-8'
   }
   next()


### PR DESCRIPTION
Currently on `POST` requests we were not doing signature checks so an attacker could theoretically spam the sharedInbox with fake content.

Issue was likely due to the signature validation being disabled because the `content-type` was overridden at a middleware, which broke any signature where the service also had the `content-type` as part of the signature. I'm looking at you Mastodon

There's a bit of a refactor also going on to make the code path hopefully easier to understand, with explicit separate routes for `GET` and `POST` requests.

Also fixing a minor issue around signature requery - while we did support requerying the signature of users at least every 24 hours, that codepath was only working for `POST` requests, so only for people sending new content. Anyone trying to call the GET endpoints would remain stuck with their public key unchanged. This is updated by making sure we allow GET requests to intiate a re-query at least every 24 hours.

Also the caching for the keys didn't work, as the cache key was never set. This is now sorted, so hopefully there'll be a slight performance gain as well

Oh yeah and the typo hurt my eyes a bit, so that's sorted as well