### PR TITLE
optimizeMedia: preserve GIF losslessness sometimes

### DIFF
--- a/packages/backend/utils/optimizeMedia.ts
+++ b/packages/backend/utils/optimizeMedia.ts
@@ -98,8 +98,17 @@ export default async function optimizeMedia(
         }
       }
       if (fileAndExtension[1] == 'webp') {
+        let lossless = false
+        // if the input is PNG we probably want the output to be lossless too
+        // also allow GIFs under 2MB to be kept as lossless
+        // (smaller GIFs are likely to be something like pixel art
+        // where we want to keep fine detail)
+        const lower = inputPath.toLowerCase()
+        if (lower.endsWith('png') || (lower.endsWith('gif') && metadata.size && metadata.size <= 1024**2*2)) {
+          lossless = true
+        }
         conversion.webp({
-          lossless: inputPath.toLowerCase().endsWith('png')
+          lossless: lossless
         })
       }
       await conversion.toFile(outputPath)


### PR DESCRIPTION
For huge GIFs it makes sense to convert them to video so they're not eating up too much bandwidth, but GIFs are often used for things like pixel art or other things where the fine details actually matter. Crunching those down doesn't save much space, but exponentially reduces the quality, so it's nice to preserve that if possible.

This updates the lossless check so it also produces lossless WEBPs if the input file is a GIF under 2MB. Since wafrn's happy serving still images that are 2MB, seems like an arbitrary but fair cutoff.

Something else worth keeping in mind is some of these pixel art GIFs actually get compressed to lossy WEBP that's *bigger* than the source image! So this change will not only preserve quality, it might actually be better for bandwidth too. For example, I tested with a 40KB pixel art GIF. wafrn recompressed that into a 4**2**KB WEBP that looks much worse than the original, while a lossless WEBP is 34KB and looks as good as the input GIF.