### PR TITLE
optimizeMedia: fix gif filesize check

### DIFF
--- a/packages/backend/utils/optimizeMedia.ts
+++ b/packages/backend/utils/optimizeMedia.ts
@@ -98,13 +98,14 @@ export default async function optimizeMedia(
         }
       }
       if (fileAndExtension[1] == 'webp') {
+        let stat = await fs.promises.stat(inputPath)
         let lossless = false
         // if the input is PNG we probably want the output to be lossless too
         // also allow GIFs under 2MB to be kept as lossless
         // (smaller GIFs are likely to be something like pixel art
         // where we want to keep fine detail)
         const lower = inputPath.toLowerCase()
-        if (lower.endsWith('png') || (lower.endsWith('gif') && metadata.size && metadata.size <= 1024**2*2)) {
+        if (lower.endsWith('png') || (lower.endsWith('gif') && stat.size <= 1024**2*2)) {
           lossless = true
         }
         conversion.webp({


### PR DESCRIPTION
Apparently sharp only returns the size if the input is a stream or buffer, which it isn't here. We'll have to check that another way.