### PR TITLE
Add jq and xxd to the packages needed to be installed

### DIFF
--- a/install/installer.sh
+++ b/install/installer.sh
@@ -136,7 +136,7 @@ echo "Installing packages"
 echo "-------------------"
 
 sudo apt update
-sudo apt install -y git postgresql-client curl lsb-release wget build-essential sudo
+sudo apt install -y git postgresql-client curl lsb-release wget build-essential sudo jq xxd
 
 echo
 echo "-----------------"


### PR DESCRIPTION
They are needed to generate secrets but are not always available on a fresh debian install