### PR TITLE
Added "replying to:" line to post-fragment replies

### DIFF
--- a/packages/frontend/src/app/components/post-fragment/post-fragment.component.html
+++ b/packages/frontend/src/app/components/post-fragment/post-fragment.component.html
@@ -27,6 +27,14 @@
     [ngClass]="{ hidden: (fragment().content_warning || fragment().muted_words_cw) && !showSensitiveContent() }"
     >
     @for (block of wafrnFormattedContent(); track $index) {
+    <!-- The thing that I really struggled at here is giving this @if a condition that made sense
+         for posts which already have the mentions in the body of the post. I failed to find one.
+    -->
+      @if (this.fragment().mentionPost?.length != 0) {
+        <section style="border-bottom: 1px solid var(--mat-sys-surface-container-highest); width: fit-content;">
+          <span><small><span style="color: var(--mat-sys-outline)">{{ 'post-fragment.replyingTo' | translate }}</span><a *ngFor="let url of mentionPosts">{{ url }} </a></small></span>
+        </section>
+      }
       <div #mediaInline class="fragment-content overflow-hidden">
         <div [injectHTML]="block" class="post-text"></div>
         @if (typeof block !== 'string') {

--- a/packages/frontend/src/app/components/post-fragment/post-fragment.component.ts
+++ b/packages/frontend/src/app/components/post-fragment/post-fragment.component.ts
@@ -20,6 +20,8 @@ import { EmojiReactComponent } from '../emoji-react/emoji-react.component'
 import { PostHeaderComponent } from '../post/post-header/post-header.component'
 import { SingleAskComponent } from '../single-ask/single-ask.component'
 
+import { TranslateModule } from '@ngx-translate/core'
+
 import { Subscription } from 'rxjs'
 import { PostLinkModule } from 'src/app/directives/post-link/post-link.module'
 import Viewer from 'viewerjs'
@@ -48,7 +50,8 @@ type EmojiReaction = {
     InjectHtmlModule,
     PostHeaderComponent,
     SingleAskComponent,
-    PostLinkModule
+    PostLinkModule,
+    TranslateModule
   ],
   templateUrl: './post-fragment.component.html',
   styleUrl: './post-fragment.component.scss'
@@ -58,10 +61,12 @@ export class PostFragmentComponent implements OnChanges, OnDestroy {
   forceExpand = output<boolean>()
   showSensitiveContent = signal<boolean>(false)
   emojiCollection = signal<EmojiReaction[]>([])
+  isLocalUser = true
   likeSubscription!: Subscription
   emojiSubscription!: Subscription
   followsSubscription!: Subscription
   userId!: string
+  mentionPosts: any
   availableEmojiNames: string[] = []
 
   reactionLoading = signal<boolean>(false)
@@ -160,6 +165,11 @@ export class PostFragmentComponent implements OnChanges, OnDestroy {
         this.renderEmojiReact(emojiEvent)
       }
     })
+
+    // it is a shame that I can't just do this DIRECTLY in the template
+    // it took me embarassingly long to figure out
+    // - alexia
+    this.mentionPosts = this.fragment().mentionPost?.map((post) => post.url)
     this.initializeContent()
   }
 

--- a/packages/frontend/src/assets/i18n/en.json
+++ b/packages/frontend/src/assets/i18n/en.json
@@ -1,136 +1,139 @@
 {
-    "login": {
-        "welcomeBack": "Welcome back!",
-        "exploreWithoutAccount": "Click here to take a look without an account!",
-        "dontHaveAccount": "Don't have an account?",
-        "register": "Register now!",
-        "checkSpam": "If you have any issue, please check your spam folder!",
-        "email": "Email",
-        "password": "Password",
-        "mfaToken": "Token",
-        "mfaTokenEnter": "Enter your token from your Authenticator application",
-        "forgottenPassword": "Forgot password? Click here!",
-        "showPassword": "Show password",
-        "hidePassword": "Hide password",
-        "loginButton": "Log in"
+  "login": {
+    "welcomeBack": "Welcome back!",
+    "exploreWithoutAccount": "Click here to take a look without an account!",
+    "dontHaveAccount": "Don't have an account?",
+    "register": "Register now!",
+    "checkSpam": "If you have any issue, please check your spam folder!",
+    "email": "Email",
+    "password": "Password",
+    "mfaToken": "Token",
+    "mfaTokenEnter": "Enter your token from your Authenticator application",
+    "forgottenPassword": "Forgot password? Click here!",
+    "showPassword": "Show password",
+    "hidePassword": "Hide password",
+    "loginButton": "Log in"
+  },
+  "notifications": {
+    "loadingMore": "Loading more notifications",
+    "refresh": "Refresh"
+  },
+  "menu": {
+    "login": "Log in",
+    "register": "Register",
+    "dashboard": "Dashboard",
+    "dashboardHover": "View dashboard",
+    "writeWoot": "Write new woot",
+    "notifications": "Notifications",
+    "explore": "Explore",
+    "exploreWafrn": "Explore WAFRN",
+    "exploreFediverse": "Wafrn & friends",
+    "unansweredAsks": "Unanswered Asks",
+    "privateMessages": "Private messages",
+    "search": "Search",
+    "myBlog": "My blog",
+    "privacy": "Privacy Policy",
+    "source": "View the source!",
+    "patreon": "Patreon",
+    "kofi": "Ko-fi",
+    "logout": "Log out",
+    "faq": "Frequently Asked Questions",
+    "settings": {
+      "title": "Settings",
+      "follows": "Manage followers",
+      "enableBluesky": "Enable Bluesky",
+      "editProfile": "Preferences and Profile",
+      "themeEditor": "Theme editor",
+      "mutedUsers": "Muted users",
+      "mutedPosts": "Muted posts",
+      "bookmarkedPosts": "Bookmarked posts",
+      "myBlockedUsers": "Blocked users",
+      "myBlockedServers": "Blocked servers",
+      "importFollows": "Import followers",
+      "superSecretMenu": "Super Secret Menu"
     },
-	"notifications": {
-		"loadingMore": "Loading more notifications",
-		"refresh": "Refresh"
-	},
-    "menu": {
-        "login": "Log in",
-        "register": "Register",
-        "dashboard": "Dashboard",
-        "dashboardHover": "View dashboard",
-        "writeWoot": "Write new woot",
-        "notifications": "Notifications",
-        "explore": "Explore",
-        "exploreWafrn": "Explore WAFRN",
-        "exploreFediverse": "Wafrn & friends",
-        "unansweredAsks": "Unanswered Asks",
-        "privateMessages": "Private messages",
-        "search": "Search",
-        "myBlog": "My blog",
-        "privacy": "Privacy Policy",
-        "source": "View the source!",
-        "patreon": "Patreon",
-        "kofi": "Ko-fi",
-        "logout": "Log out",
-        "faq": "Frequently Asked Questions",
-        "settings": {
-            "title": "Settings",
-            "follows": "Manage followers",
-            "enableBluesky": "Enable Bluesky",
-            "editProfile": "Preferences and Profile",
-            "themeEditor": "Theme editor",
-            "mutedUsers": "Muted users",
-            "mutedPosts": "Muted posts",
-            "bookmarkedPosts": "Bookmarked posts",
-            "myBlockedUsers": "Blocked users",
-            "myBlockedServers": "Blocked servers",
-            "importFollows": "Import followers",
-            "superSecretMenu": "Super Secret Menu"
-        },
-        "admin": {
-            "title": "Admin",
-            "serverList": "Server list",
-            "addEmojis": "Add emojis",
-            "reports": "Reports",
-            "bans": "Banned users",
-            "blocklist": "Blocked users",
-            "stats": "Stats",
-            "awaitingAproval": "Awaiting approval"
-        }
-    },
-    "editor": {
-        "inReplyTo": "In reply to:",
-        "quoteButton": "Quote a woot",
-        "publishWoot": "Publish this woot",
-        "directMessageWarning": "Admins of both your server and the external server can read these messages.",
-        "unlistedWarning": "Unlisted posts will get ignored by searches (TAGS INCLUDED), and will not show on explore local. but they will be shown to your followers. And if someone sends a link they will ve visible, unlike followers only. Basicaly, for when you want to post a lot but dont want to fill explore local.",
-        "directMessageWithQuoteWarning": "Quoted user will be notified of this as a mention too",
-        "sensitivePlaceholder": "What is sensitive about this woot?",
-        "wootQuoteBoxLabel": "Paste the URL of a woot to quote it. Can be the external url or the wafrn url",
-        "wootQuoteBoxPlaceholder": "Just paste the woot url",
-        "wootQuoteConfirmButton": "Add woot as quote",
-        "wootTextLabel": "Woot text",
-        "wootTextPlaceholder": "Start writing...",
-        "altTextFieldLabel": "Image Description",
-        "altTextFieldPlaceholder": "Description. Please FILL THIS",
-        "isNSFWToggle": "NSFW",
-        "mediaCountMastodonWarning": "ATTENTION! ANY FURTHER MEDIA UPLOADED WILL NOT BE DISPLAYED ON MASTODON",
-        "altTextWarning": "Please fill in the media descriptions. If you want to disable this check, you can do so in the settings.",
-        "quoteTitle": "Quoting:",
-        "tagFieldLabel": "Tags",
-        "tagSeparationNotice": "Separated by commas",
-        "ariaLabelWootPrivacy": "Edit privacy of woot",
-        "ariaLabelQuoteSetter": "Enable the quote setter",
-        "uploadMediaTooltip": "Upload Media",
-        "contentWarningTooltip": "Content Warning",
-        "insertEmojiTooltip": "Insert emoji",
-        "hiddenMentionsTooltip": "Other mentioned users",
-        "editorGuide": "Doubts on how to format the text or how to start? Check <a target=\"_blank\" href=\"https://wafrn.net/faq/user\">the guide</a>"
-    },
-    "profile": {
-        "security": {
-            "header": "Security Settings",
-            "passwordChange": "Reset Password",
-            "mfa": {
-                "header": "Two Factor Authentication",
-                "setup": "Setup Two Factor Authentication",
-                "addNew": "Add new Two Factor Authenticator",
-                "friendlyNameLabel": "Friendly name, e.g. 'Work Phone' or 'Aegis'",
-                "typeLabel": "Two factor type",
-                "setupNewButton": "Set up new authenticator",
-                "tokenLabel": "Token",
-                "deleteLabel": "Delete",
-                "scanInstructions": "Scan the code below in your Authenticator application, and enter the code shown",
-                "installInstructions": "If you don't have an Authenticator app yet we suggest <a href=\"https://getaegis.app/\" target=\"_blank\">Aegis</a> (Android) or <a href=\"https://2fas.com/\" target=\"_blank\">2FAS</a> (iOS/Android)",
-                "imageAltSecret": "Authentication secret is '{{ secret }}'",
-                "secretFallback": "If you cannot read the QR code you can use code '{{ secret }}' manually in your app",
-                "confirmDeleteMessage": "Are you sure you want to delete this MFA provider? Note: deleting all MFA providers will disable MFA on your account",
-                "deleteSuccess": "MFA provider successfully removed",
-                "verifySuccess": "Success, your MFA is now enabled",
-                "verifyFailed": "Verification failed. Check your token, or if the problem persists ask an Administrator",
-                "errorMessageGeneric": "There was an issue with your request. Try again, or ask an Administrator for help",
-                "noMfa": "You do not have MFA enabled on your account",
-                "mfaList": "You have the following MFA providers set up",
-                "type": {
-                    "totpLabel": "Authenticator App"
-                }
-            }
-        },
-        "tabHeaders": {
-            "profile": "Profile",
-            "preferences": "Preferences",
-            "privacySecurity": "Privacy and Security",
-            "misc": "Miscellaneous"
-        }
-    },
-    "ask-dialog-content": {
-        "askAnonymously": "Make question anonymous",
-        "askFormLabel": "Question",
-        "askButtonText": "Ask"
+    "admin": {
+      "title": "Admin",
+      "serverList": "Server list",
+      "addEmojis": "Add emojis",
+      "reports": "Reports",
+      "bans": "Banned users",
+      "blocklist": "Blocked users",
+      "stats": "Stats",
+      "awaitingAproval": "Awaiting approval"
     }
+  },
+  "editor": {
+    "inReplyTo": "In reply to:",
+    "quoteButton": "Quote a woot",
+    "publishWoot": "Publish this woot",
+    "directMessageWarning": "Admins of both your server and the external server can read these messages.",
+    "unlistedWarning": "Unlisted posts will get ignored by searches (TAGS INCLUDED), and will not show on explore local. but they will be shown to your followers. And if someone sends a link they will ve visible, unlike followers only. Basicaly, for when you want to post a lot but dont want to fill explore local.",
+    "directMessageWithQuoteWarning": "Quoted user will be notified of this as a mention too",
+    "sensitivePlaceholder": "What is sensitive about this woot?",
+    "wootQuoteBoxLabel": "Paste the URL of a woot to quote it. Can be the external url or the wafrn url",
+    "wootQuoteBoxPlaceholder": "Just paste the woot url",
+    "wootQuoteConfirmButton": "Add woot as quote",
+    "wootTextLabel": "Woot text",
+    "wootTextPlaceholder": "Start writing...",
+    "altTextFieldLabel": "Image Description",
+    "altTextFieldPlaceholder": "Description. Please FILL THIS",
+    "isNSFWToggle": "NSFW",
+    "mediaCountMastodonWarning": "ATTENTION! ANY FURTHER MEDIA UPLOADED WILL NOT BE DISPLAYED ON MASTODON",
+    "altTextWarning": "Please fill in the media descriptions. If you want to disable this check, you can do so in the settings.",
+    "quoteTitle": "Quoting:",
+    "tagFieldLabel": "Tags",
+    "tagSeparationNotice": "Separated by commas",
+    "ariaLabelWootPrivacy": "Edit privacy of woot",
+    "ariaLabelQuoteSetter": "Enable the quote setter",
+    "uploadMediaTooltip": "Upload Media",
+    "contentWarningTooltip": "Content Warning",
+    "insertEmojiTooltip": "Insert emoji",
+    "hiddenMentionsTooltip": "Other mentioned users",
+    "editorGuide": "Doubts on how to format the text or how to start? Check <a target=\"_blank\" href=\"https://wafrn.net/faq/user\">the guide</a>"
+  },
+  "profile": {
+    "security": {
+      "header": "Security Settings",
+      "passwordChange": "Reset Password",
+      "mfa": {
+        "header": "Two Factor Authentication",
+        "setup": "Setup Two Factor Authentication",
+        "addNew": "Add new Two Factor Authenticator",
+        "friendlyNameLabel": "Friendly name, e.g. 'Work Phone' or 'Aegis'",
+        "typeLabel": "Two factor type",
+        "setupNewButton": "Set up new authenticator",
+        "tokenLabel": "Token",
+        "deleteLabel": "Delete",
+        "scanInstructions": "Scan the code below in your Authenticator application, and enter the code shown",
+        "installInstructions": "If you don't have an Authenticator app yet we suggest <a href=\"https://getaegis.app/\" target=\"_blank\">Aegis</a> (Android) or <a href=\"https://2fas.com/\" target=\"_blank\">2FAS</a> (iOS/Android)",
+        "imageAltSecret": "Authentication secret is '{{ secret }}'",
+        "secretFallback": "If you cannot read the QR code you can use code '{{ secret }}' manually in your app",
+        "confirmDeleteMessage": "Are you sure you want to delete this MFA provider? Note: deleting all MFA providers will disable MFA on your account",
+        "deleteSuccess": "MFA provider successfully removed",
+        "verifySuccess": "Success, your MFA is now enabled",
+        "verifyFailed": "Verification failed. Check your token, or if the problem persists ask an Administrator",
+        "errorMessageGeneric": "There was an issue with your request. Try again, or ask an Administrator for help",
+        "noMfa": "You do not have MFA enabled on your account",
+        "mfaList": "You have the following MFA providers set up",
+        "type": {
+          "totpLabel": "Authenticator App"
+        }
+      }
+    },
+    "tabHeaders": {
+      "profile": "Profile",
+      "preferences": "Preferences",
+      "privacySecurity": "Privacy and Security",
+      "misc": "Miscellaneous"
+    }
+  },
+  "ask-dialog-content": {
+    "askAnonymously": "Make question anonymous",
+    "askFormLabel": "Question",
+    "askButtonText": "Ask"
+  },
+  "post-fragment": {
+    "replyingTo": "replying to: "
+  }
 }


### PR DESCRIPTION
The logic for *when* these are displayed currently does *not* take into account whether the post they're being shown on already has mentions in the post body. It also does not use `isFediverseUser` or `isLocalUser` because highkey I couldn't figure them out lmao ;w;

Localization is present. Maintainer Edits are enabled. My hopes that I didn't accidentally leave something in that wasn't supposed to be there is high (I checked like twice pls let there not be stuff still lmao)

I wish I could tell you what happened with the `en.json` I think zed might've formatted it idk