### PR TITLE
fix: padding size

### DIFF
--- a/packages/frontend/src/styles.scss
+++ b/packages/frontend/src/styles.scss
@@ -90,7 +90,7 @@ body {
 }
 
 .wafrn-content {
-  padding-top: 4rem;
+  padding-top: 1.5rem;
 }
 
 // No JavaScript
@@ -266,6 +266,10 @@ body {
 
   /* END fullwidth post style */
 
+  /* Flush first post to match 0 margin sides*/
+  .wafrn-content {
+    padding-top: 0;
+  }
 }
 
 .shortened-post {


### PR DESCRIPTION
Since we're using a toolbar setup now the reload button isn't cramped in the corner. Probably...

## Before

<img width="1680" height="996" alt="image" src="https://github.com/user-attachments/assets/f7a144b6-590e-47c1-b74e-d1ca69fe94bc" />

<img width="427" height="919" alt="image" src="https://github.com/user-attachments/assets/9eaf1e69-f654-4e23-8a2f-1077eaa633cd" />

## After

<img width="1680" height="996" alt="image" src="https://github.com/user-attachments/assets/da0215c6-a60a-46c7-9283-abeb6ecf99b9" />

<img width="427" height="919" alt="image" src="https://github.com/user-attachments/assets/511ea3e9-27fa-490d-a60c-0bd1d3408bbf" />
