### PR TITLE
Top toolbar mode

### DIFF
--- a/packages/frontend/src/app/components/color-scheme-switcher/color-scheme-switcher.component.html
+++ b/packages/frontend/src/app/components/color-scheme-switcher/color-scheme-switcher.component.html
@@ -63,6 +63,11 @@
     >
   </button>
   <button mat-menu-item class="pl-1">
+    <mat-checkbox [checked]="topToolbarMode" (click)="updateTopToolbar(true)"
+      ><span class="theme-selector-button">Top Toolbar</span></mat-checkbox
+    >
+  </button>
+  <button mat-menu-item class="pl-1">
     <mat-checkbox [checked]="horizontalMenuMode" (click)="updateHorizontalMenu(true)"
       ><span class="theme-selector-button">Horizontal Menu</span></mat-checkbox
     >
@@ -184,4 +189,7 @@
 
 @if (centerLayoutMode) {
   <link href="/assets/themes/center-column.css" rel="stylesheet" />
+}
+@if (topToolbarMode) {
+  <link href="/assets/themes/top-toolbar.css" rel="stylesheet" />
 }

--- a/packages/frontend/src/app/components/color-scheme-switcher/color-scheme-switcher.component.ts
+++ b/packages/frontend/src/app/components/color-scheme-switcher/color-scheme-switcher.component.ts
@@ -92,6 +92,7 @@ export class ColorSchemeSwitcherComponent {
 
   // Options
   centerLayoutMode = localStorage.getItem('centerLayout') === 'true'
+  topToolbarMode = localStorage.getItem('topToolbar') === 'true'
   horizontalMenuMode = localStorage.getItem('horizontalMenu') === 'true'
 
   // Icons
@@ -157,6 +158,13 @@ export class ColorSchemeSwitcherComponent {
       await this.loginService.updateUserOptions([
         { name: 'wafrn.centerLayout', value: this.centerLayoutMode.toString() }
       ])
+    }
+  }
+
+  async updateTopToolbar(forceUpdate = false) {
+    this.topToolbarMode = !this.topToolbarMode
+    if (forceUpdate && this.loginService.checkUserLoggedIn()) {
+      await this.loginService.updateUserOptions([{ name: 'wafrn.topToolbar', value: this.topToolbarMode.toString() }])
     }
   }
 

--- a/packages/frontend/src/app/components/navigation-menu/navigation-menu.component.html
+++ b/packages/frontend/src/app/components/navigation-menu/navigation-menu.component.html
@@ -45,7 +45,9 @@
         </div>
       }
     </mat-toolbar>
-    <br/><br/>
+    <button *ngIf="true" (click)="refresh()" mat-mini-fab color="default" aria-label="Refresh" class="refresh-button">
+      <fa-icon [icon]="reloadIcon" />
+    </button>
     <main id="main-content" class="wafrn-content">
       @if (maintenanceMode) {
         <div [innerHtml]="maintenanceMessage"></div>
@@ -54,18 +56,6 @@
     </main>
   </mat-drawer-content>
 </mat-drawer-container>
-
-<button
-  *ngIf="true"
-  (click)="refresh()"
-  mat-mini-fab
-  color="default"
-  aria-label="Refresh"
-  class="refresh-button"
-  style="position: fixed; z-index: 500; top: 1em; right: 1em"
->
-  <fa-icon [icon]="reloadIcon" />
-</button>
 
 <button
   *ngIf="!mobile"

--- a/packages/frontend/src/app/components/new-editor/new-editor.component.html
+++ b/packages/frontend/src/app/components/new-editor/new-editor.component.html
@@ -1,4 +1,4 @@
-<mat-card class="p-3 mb-6 lg:mx-4 wafrn-container">
+<mat-card class="p-3 mb-6 lg:mx-4 wafrn-container wafrn-post-editor">
   <div class="below-editor-toolbar">
     <div class="below-editor-toolbar-leftside">
       <button mat-icon-button class="close-post-btn" (click)="closeEditor()">
@@ -12,7 +12,7 @@
         class="input-height-btn"
         [matTooltip]="getPrivacyIconName()"
         [disabled]="editing"
-        >
+      >
         <fa-icon size="lg" [icon]="getPrivacyIcon()"></fa-icon>
       </button>
       <button
@@ -21,7 +21,7 @@
         (click)="quoteOpen = !quoteOpen"
         class="input-height-btn"
         matTooltip="{{ 'editor.quoteButton' | translate }}"
-        >
+      >
         <fa-icon size="lg" [icon]="quoteIcon"></fa-icon>
       </button>
       @if (pollQuestions.length === 0) {
@@ -34,7 +34,7 @@
         mat-icon-button
         (click)="showContentWarning = !showContentWarning"
         matTooltip="{{ 'editor.contentWarningTooltip' | translate }}"
-        >
+      >
         @if (contentWarning.includes('meta')) {
           <fa-icon size="lg" [icon]="skull"></fa-icon>
         } @else {
@@ -46,11 +46,11 @@
         mat-icon-button
         (click)="openEmojiSelection()"
         matTooltip="{{ 'editor.insertEmojiTooltip' | translate }}"
-        >
+      >
         <svg width="20px" height="20px" viewBox="0 0 1000 1000" fill="currentColor" class="vertical-align-middle">
           <path
             d="M958 104h-62V43q0-17-12-29T855 2h-87q-17 0-29 12t-12 29v61h-62q-17 0-29 12t-12 29v4q-81-34-169-34-116 0-217 59-97 57-154 154-58 100-58 216.5T84 761q57 98 154 155 101 58 217.5 58T672 916q97-57 154-155 59-100 59-216 0-88-34-168h4q17 0 29-12t12-29v-62h62q17 0 29-12t12-29v-88q0-17-12-29t-29-12zM644 348q29 0 49.5 20.5t20.5 49-20.5 49T644 487t-49.5-20.5-20.5-49 20.5-49T644 348zm-377 0q29 0 49.5 20.5t20.5 49-20.5 49T267 487t-49.5-20.5-20.5-49 20.5-49T267 348zm473 255q-10 70-50.5 126.5t-102 88.5-132 32-132-32-102-88.5T171 603q-2-16 8.5-27.5T206 564h499q16 0 26.5 11.5T740 603zm218-370H855v103h-87V233H665v-88h103V43h87v102h103v88z"
-            />
+          />
         </svg>
       </button>
       <!--
@@ -76,7 +76,7 @@
           (postCreatorForm.value.content === initialContent && tags.length === 0 && uploadedMedias.length === 0)
         "
         matTooltip="{{ 'editor.publishWoot' | translate }}"
-        >
+      >
         <fa-icon size="lg" [icon]="postIcon"></fa-icon>
       </button>
     </div>
@@ -113,7 +113,7 @@
           [(ngModel)]="contentWarning"
           placeholder="{{ 'editor.sensitivePlaceholder' | translate }}"
           matNativeControl
-          />
+        />
       </mat-form-field>
     }
 
@@ -138,7 +138,7 @@
               [(ngModel)]="urlPostToQuote"
               placeholder="{{ 'editor.wootQuoteBoxPlaceholder' | translate }}"
               matNativeControl
-              />
+            />
           </mat-form-field>
           <button
             (click)="loadQuote()"
@@ -146,7 +146,7 @@
             color="primary"
             class="w-full"
             [disabled]="urlPostToQuote === ''"
-            >
+          >
             {{ 'editor.wootQuoteConfirmButton' | translate }}
           </button>
         </mat-card>
@@ -276,7 +276,7 @@
       [hidden]="suggestions.length === 0"
       [style.left.px]="cursorPosition.x"
       [style.top.px]="cursorPosition.y"
-      >
+    >
       <div class="flex flex-column gap-2">
         @for (user of suggestions; track $index) {
           <div (click)="insertMention(user)" class="flex gap-2 align-items-center suggestion-item">

--- a/packages/frontend/src/assets/themes/top-toolbar.css
+++ b/packages/frontend/src/assets/themes/top-toolbar.css
@@ -11,6 +11,10 @@
     padding-top: calc(64px + 1em);
   }
 
+  .wafrn-post-editor {
+    margin-top: 3rem;
+  }
+
   .refresh-button {
     bottom: unset;
     top: calc(64px + 1em);

--- a/packages/frontend/src/assets/themes/top-toolbar.css
+++ b/packages/frontend/src/assets/themes/top-toolbar.css
@@ -1,0 +1,29 @@
+.wafrn-toolbar {
+  bottom: unset;
+  border-top: unset;
+  border-bottom: 1px solid var(--mat-sys-outline-variant);
+  box-shadow: var(--mat-sys-level2);
+}
+
+/* Small-Screen media queries. */
+@media screen and (max-width: 992px) {
+  .wafrn-content {
+    padding-top: calc(64px + 1em);
+  }
+
+  .refresh-button {
+    bottom: unset;
+    top: calc(64px + 1em);
+  }
+}
+
+/* mat-toolbar breakpoint */
+@media screen and (max-width: 599px) {
+  .wafrn-content {
+    padding-top: calc(56px + 1em);
+  }
+
+  .refresh-button {
+    top: calc(56px + 1em);
+  }
+}

--- a/packages/frontend/src/styles.scss
+++ b/packages/frontend/src/styles.scss
@@ -17,17 +17,31 @@
 
 html {
   color-scheme: light dark;
-  @include mat.theme((color: mat.$violet-palette,
-      density: 0));
+  @include mat.theme(
+    (
+      color: mat.$violet-palette,
+      density: 0
+    )
+  );
 }
 
 // HACK: Have to make dummy theme to initialize typography
-$theme: mat.define-theme((color: (primary: mat.$violet-palette )));
+$theme: mat.define-theme(
+  (
+    color: (
+      primary: mat.$violet-palette
+    )
+  )
+);
 
 @include mat.typography-hierarchy($theme);
 
 :root {
-  @include mat.badge-overrides((background-color: var(--mat-button-filled-container-color, var(--mat-sys-primary))));
+  @include mat.badge-overrides(
+    (
+      background-color: var(--mat-button-filled-container-color, var(--mat-sys-primary))
+    )
+  );
 }
 
 // Variables
@@ -37,7 +51,7 @@ $theme: mat.define-theme((color: (primary: mat.$violet-palette )));
 
   --info-card-info-background: light-dark(#d5e3fe, #3a475d);
   --info-card-warning-background: light-dark(#d7c3b8, #52443c);
-  --mat-dialog-container-max-width: 960px
+  --mat-dialog-container-max-width: 960px;
 }
 
 // Fonts overrides
@@ -49,16 +63,29 @@ $theme: mat.define-theme((color: (primary: mat.$violet-palette )));
 body,
 html {
   font-family: Inter, sans-serif !important;
-  font-feature-settings: 'liga' 1, 'calt' 1, 'tnum' 1, 'case' 1, 'zero' 1, 'ss01' 0, 'ss02' 1 !important;
+  font-feature-settings:
+    'liga' 1,
+    'calt' 1,
+    'tnum' 1,
+    'case' 1,
+    'zero' 1,
+    'ss01' 0,
+    'ss02' 1 !important;
 }
 
 @supports (font-variation-settings: normal) {
-
   :root,
   body,
   html {
     font-family: InterVariable, sans-serif !important;
-    font-feature-settings: 'liga' 1, 'calt' 1, 'tnum' 1, 'case' 1, 'zero' 1, 'ss01' 0, 'ss02' 1 !important;
+    font-feature-settings:
+      'liga' 1,
+      'calt' 1,
+      'tnum' 1,
+      'case' 1,
+      'zero' 1,
+      'ss01' 0,
+      'ss02' 1 !important;
   }
 }
 
@@ -232,7 +259,6 @@ body {
 /* Small-Screen media queries. */
 /* Currently encompasses the bottom-sheet style for dialogs, as well as the full-width post style for narrow screens.*/
 @media screen and (max-width: 800px) {
-
   /* START bottom-sheet */
   :root {
     --mat-dialog-container-shape: 16px 16px 0px 0px;
@@ -242,7 +268,7 @@ body {
     align-items: flex-end !important;
   }
 
-  [id*="mat-mdc-dialog-"] {
+  [id*='mat-mdc-dialog-'] {
     animation: 300ms slideup;
     --mat-dialog-transition-duration: 0ms !important;
   }
@@ -377,7 +403,6 @@ mat-tab-header {
   }
 }
 
-
 .wafrn-toolbar {
   position: fixed;
   bottom: 0;
@@ -388,4 +413,29 @@ mat-tab-header {
   border-top: 1px solid var(--mat-sys-outline-variant);
   --mat-list-list-item-one-line-container-height: 52px;
   --mat-sys-hover-state-layer-opacity: 0;
+}
+
+.refresh-button {
+  /* Evil specificity hack */
+  :root & {
+    position: fixed;
+  }
+  z-index: 500;
+  top: 1em;
+  right: 1em;
+}
+
+/* Mobile mode breakpoint*/
+@media screen and (max-width: 992px) {
+  .refresh-button {
+    top: unset;
+    bottom: calc(64px + 1em);
+  }
+}
+
+/* mat-toolbar breakpoint */
+@media screen and (max-width: 599px) {
+  .refresh-button {
+    bottom: calc(56px + 1em);
+  }
 }


### PR DESCRIPTION
Adds the option to have the toolbar on top for mobile and also de-janks the refresh button. I also added a tiny top margin to match the border radius on the first post/profile.

Ignore how the images are broken, dev env moment.

## New Feature

Top Toolbar

<img width="845" height="921" alt="image" src="https://github.com/user-attachments/assets/509e1cef-69bd-49cd-b7da-ca898a657879" />

<img width="845" height="921" alt="image" src="https://github.com/user-attachments/assets/6695ecf7-3549-4191-be44-3ace95ec35d8" />

Bottom Toolbar

<img width="845" height="921" alt="image" src="https://github.com/user-attachments/assets/6d386ea4-ad77-4a47-8fe6-316cb3c0f604" />

<img width="845" height="921" alt="image" src="https://github.com/user-attachments/assets/fb69ebee-761e-4756-b1c1-ea1e48bb76b9" />
