### PR TITLE
Combine bsky hearts with emoji hearts

### DIFF
--- a/packages/frontend/src/app/components/post-fragment/post-fragment.component.ts
+++ b/packages/frontend/src/app/components/post-fragment/post-fragment.component.ts
@@ -210,6 +210,14 @@ export class PostFragmentComponent implements OnChanges, OnDestroy {
       this.emojiCollection.set([])
       return
     }
+
+    // Evil fix for bsky emoji text heart reactions
+    this.fragment().emojiReactions.forEach((reaction) => {
+      if (reaction.content === '❤') {
+        reaction.content = '♥️'
+      }
+    })
+
     this.fragment().emojiReactions.forEach((reaction) => {
       const hasReaction = !!emojiReactions[reaction.content]
       if (!hasReaction) {


### PR DESCRIPTION
Combines bsky unicode hearts with emoji hearts. This is a frontend evil fix to cover for fixing it on the backend.

## Before

<img width="208" height="164" alt="image" src="https://github.com/user-attachments/assets/5d32ba54-8a20-4bcc-980b-8fdee4f3435d" />

## After

<img width="208" height="164" alt="image" src="https://github.com/user-attachments/assets/df52eff0-2340-47fe-8ce5-6e326a31e8e3" />