### PR TITLE
aqua: a few theme improvements

### DIFF
--- a/packages/frontend/src/assets/themes/aqua.css
+++ b/packages/frontend/src/assets/themes/aqua.css
@@ -1,7 +1,7 @@
 /* theme by @easterman@app.wafrn.net */
 :root {
     --mat-sys-on-primary-container: teal;
-    --mat-sys-primary: white;
+    --mat-sys-primary: light-dark(black, white);
 }
 
 @keyframes cursor {
@@ -12,7 +12,6 @@
 * {
     font-family: "Lucida Grande", "Lucida Sans Unicode", Helvetica, sans-serif !important;
     font-feature-settings: normal !important;
-    background-image: inherit;
 	animation-name: cursor;
 	animation-duration: 5s;
 	animation-iteration-count: infinite;


### PR DESCRIPTION
These are a couple minor things I ran into while using the theme.

* Fix the primary colour so it renders properly in light mode
* Remove background-image: inherit, which seems to cause more problems than it fixes (breaks Youtube preview images, etc)