### PR TITLE
Improve preferences menu UX

### DIFF
--- a/packages/frontend/src/app/pages/profile/edit-profile/edit-profile.component.html
+++ b/packages/frontend/src/app/pages/profile/edit-profile/edit-profile.component.html
@@ -1,5 +1,11 @@
 <mat-card class="p-3 mb-6 lg:mx-4 wafrn-container">
-  <mat-tab-group mat-stretch-tabs="false" mat-align-tabs="start" dynamicHeight preserveContent>
+  <mat-tab-group
+    mat-stretch-tabs="false"
+    mat-align-tabs="start"
+    dynamicHeight
+    preserveContent
+    (selectedIndexChange)="selectedIndex.set($event)"
+  >
     <form [hidden]="loading" [formGroup]="editProfileForm" (ngSubmit)="onSubmit()">
       <hr />
       <mat-tab label="{{ 'profile.tabHeaders.profile' | translate }}">
@@ -349,19 +355,21 @@
         </mat-card>
         -->
 
-  <div class="flex">
-    <button
-      (click)="onSubmit()"
-      [disabled]="!editProfileForm.valid || loading"
-      mat-raised-button
-      color="primary"
-      icon="pi pi-user"
-      class="w-full mt-4"
-    >
-      {{ 'profile.updateButton' | translate }}
-    </button>
-    @if (loading) {
-      <mat-spinner diameter="24" class="mt-5 mx-3"></mat-spinner>
-    }
-  </div>
+  @if (showUpdateButton()) {
+    <div class="flex">
+      <button
+        (click)="onSubmit()"
+        [disabled]="!editProfileForm.valid || loading"
+        mat-raised-button
+        color="primary"
+        icon="pi pi-user"
+        class="w-full mt-4"
+      >
+        {{ 'profile.updateButton' | translate }}
+      </button>
+      @if (loading) {
+        <mat-spinner diameter="24" class="mt-5 mx-3"></mat-spinner>
+      }
+    </div>
+  }
 </mat-card>

--- a/packages/frontend/src/app/pages/profile/edit-profile/edit-profile.component.html
+++ b/packages/frontend/src/app/pages/profile/edit-profile/edit-profile.component.html
@@ -38,22 +38,46 @@
           ></textarea>
         </mat-form-field>
         <hr />
-        <p [hidden]="loading" class="w-full">{{ 'profile.profile.extraInfoHead' | translate }}</p>
+        <p>{{ 'profile.profile.extraInfoHead' | translate }}</p>
         @for (attachment of fediAttachments; track $index) {
-          <form [hidden]="loading">
-            <div class="w-full">
-              <mat-form-field class="w-50">
+          <form>
+            <div class="flex align-items-center fedi-attachment-list">
+              <mat-form-field class="fedi-attachment">
                 <mat-label>{{ 'profile.profile.fieldPropertyName' | translate }}</mat-label>
-                <input [ngModelOptions]="{ standalone: true }" [(ngModel)]="fediAttachments[$index].name" matInput />
+                <input
+                  [ngModelOptions]="{ standalone: true }"
+                  [disabled]="loading"
+                  [(ngModel)]="fediAttachments[$index].name"
+                  required
+                  matInput
+                />
               </mat-form-field>
-              <mat-form-field class="w-50">
+              <mat-form-field class="fedi-attachment">
                 <mat-label>{{ 'profile.profile.fieldPropertyValue' | translate }}</mat-label>
-                <input [ngModelOptions]="{ standalone: true }" [(ngModel)]="fediAttachments[$index].value" matInput />
+                <input
+                  [ngModelOptions]="{ standalone: true }"
+                  [disabled]="loading"
+                  [(ngModel)]="fediAttachments[$index].value"
+                  required
+                  matInput
+                />
               </mat-form-field>
+              <!-- EVIL CENTERING (evil) -->
+              <button
+                (click)="removeFediAttachment($index)"
+                [disabled]="loading"
+                mat-button
+                class="mb-4 remove-fedi-attachment"
+              >
+                <fa-icon [icon]="faMinus" class="m-1"></fa-icon>
+              </button>
             </div>
           </form>
         }
-        <div [hidden]="loading" (click)="addFediAttachment()">+</div>
+        <button (click)="addFediAttachment()" [disabled]="loading" mat-stroked-button class="add-fedi-attachment">
+          <fa-icon [icon]="faPlus" class="m-1"></fa-icon>
+          {{ 'profile.profile.addAttachment' | translate }}
+        </button>
       </mat-tab>
       <mat-tab label="{{ 'profile.tabHeaders.preferences' | translate }}">
         <h5 class="w-full">{{ 'profile.preferences.notificationFilters' | translate }}</h5>

--- a/packages/frontend/src/app/pages/profile/edit-profile/edit-profile.component.html
+++ b/packages/frontend/src/app/pages/profile/edit-profile/edit-profile.component.html
@@ -325,14 +325,19 @@
         </mat-card>
         -->
 
-  <button
-    (click)="onSubmit()"
-    [disabled]="!editProfileForm.valid"
-    mat-raised-button
-    color="primary"
-    icon="pi pi-user"
-    class="w-full mt-4"
-  >
-    {{ 'profile.updateButton' | translate }}
-  </button>
+  <div class="flex">
+    <button
+      (click)="onSubmit()"
+      [disabled]="!editProfileForm.valid || loading"
+      mat-raised-button
+      color="primary"
+      icon="pi pi-user"
+      class="w-full mt-4"
+    >
+      {{ 'profile.updateButton' | translate }}
+    </button>
+    @if (loading) {
+      <mat-spinner diameter="24" class="mt-5 mx-3"></mat-spinner>
+    }
+  </div>
 </mat-card>

--- a/packages/frontend/src/app/pages/profile/edit-profile/edit-profile.component.html
+++ b/packages/frontend/src/app/pages/profile/edit-profile/edit-profile.component.html
@@ -259,7 +259,7 @@
             />
           </mat-form-field>
           @if (editProfileForm.value.mutedWords.split(',').length > 0) {
-            <div class="taglist flex flex-wrap mb-2">
+            <div class="flex flex-wrap gap-2 tag-list">
               @for (tag of editProfileForm.value.mutedWords.split(','); track $index) {
                 @if (tag && tag !== '' && tag.trim() !== '') {
                   <div class="tag">

--- a/packages/frontend/src/app/pages/profile/edit-profile/edit-profile.component.scss
+++ b/packages/frontend/src/app/pages/profile/edit-profile/edit-profile.component.scss
@@ -1,0 +1,15 @@
+.fedi-attachment-list {
+  column-gap: 1rem;
+}
+
+.fedi-attachment {
+  flex: 50;
+}
+
+.remove-fedi-attachment {
+  padding: 8px;
+  flex: auto;
+}
+.add-fedi-attachment {
+  padding: 0 24px 0 16px;
+}

--- a/packages/frontend/src/app/pages/profile/edit-profile/edit-profile.component.ts
+++ b/packages/frontend/src/app/pages/profile/edit-profile/edit-profile.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core'
+import { Component, computed, OnInit, signal, Signal, WritableSignal } from '@angular/core'
 import { FormControl, UntypedFormControl, UntypedFormGroup, Validators } from '@angular/forms'
 import { BlogDetails } from 'src/app/interfaces/blogDetails'
 import { Emoji } from 'src/app/interfaces/emoji'
@@ -37,6 +37,10 @@ export class EditProfileComponent implements OnInit {
     { level: 1, name: 'Only articles (Feature still in the works)' },
     { level: 2, name: 'Yes for all my posts' }
   ]
+
+  selectedIndex: WritableSignal<number> = signal<number>(0)
+  tabsToHideUpdateButton = [4, 5, 6] // we do a little trolling
+  showUpdateButton: Signal<boolean> = computed(() => this.tabsToHideUpdateButton.indexOf(this.selectedIndex()) === -1)
 
   faPlus = faPlus
   faMinus = faXmark

--- a/packages/frontend/src/app/pages/profile/edit-profile/edit-profile.component.ts
+++ b/packages/frontend/src/app/pages/profile/edit-profile/edit-profile.component.ts
@@ -9,6 +9,7 @@ import { LoginService } from 'src/app/services/login.service'
 import { MediaService } from 'src/app/services/media.service'
 import { MessageService } from 'src/app/services/message.service'
 import { ThemeService } from 'src/app/services/theme.service'
+import { faPlus, faXmark } from '@fortawesome/free-solid-svg-icons'
 
 @Component({
   selector: 'app-edit-profile',
@@ -32,10 +33,13 @@ export class EditProfileComponent implements OnInit {
     { level: 3, name: 'Disable asks' }
   ]
   rssOptions = [
-    {level: 0, name: 'No'},
-    {level: 1, name: 'Only articles (Feature still in the works)'},
-    {level: 2, name: 'Yes for all my posts'}
+    { level: 0, name: 'No' },
+    { level: 1, name: 'Only articles (Feature still in the works)' },
+    { level: 2, name: 'Yes for all my posts' }
   ]
+
+  faPlus = faPlus
+  faMinus = faXmark
 
   fediAttachments: { name: string; value: string }[] = [{ name: '', value: '' }]
   editProfileForm = new UntypedFormGroup({
@@ -103,9 +107,7 @@ export class EditProfileComponent implements OnInit {
         this.loginService.getUserDefaultPostPrivacyLevel()
       )
       let rssOptionValue = localStorage.getItem('enableRSS')
-      this.editProfileForm.controls['rssOptions'].patchValue(
-        rssOptionValue ? parseInt(rssOptionValue) : 0
-      )
+      this.editProfileForm.controls['rssOptions'].patchValue(rssOptionValue ? parseInt(rssOptionValue) : 0)
       this.editProfileForm.controls['forceClassicLogo'].patchValue(this.loginService.getForceClassicLogo())
       const federateWithThreads = localStorage.getItem('federateWithThreads')
       this.editProfileForm.controls['federateWithThreads'].patchValue(federateWithThreads === 'true')
@@ -127,7 +129,9 @@ export class EditProfileComponent implements OnInit {
         this.mediaService.checkForceClassicVideoPlayer()
       )
       this.editProfileForm.controls['disableConfetti'].patchValue(localStorage.getItem('disableConfetti') == 'true')
-      this.editProfileForm.controls['enableConfettiRecivingLike'].patchValue(localStorage.getItem('enableConfettiRecivingLike') == 'true')
+      this.editProfileForm.controls['enableConfettiRecivingLike'].patchValue(
+        localStorage.getItem('enableConfettiRecivingLike') == 'true'
+      )
       this.editProfileForm.controls['disableSounds'].patchValue(localStorage.getItem('disableSounds') == 'true')
 
       this.editProfileForm.controls['forceClassicMediaView'].patchValue(
@@ -251,6 +255,10 @@ export class EditProfileComponent implements OnInit {
 
   addFediAttachment() {
     this.fediAttachments.push({ name: '', value: '' })
+  }
+
+  removeFediAttachment(index: number) {
+    this.fediAttachments.splice(index, 1)
   }
 
   getAttachmentValue() {

--- a/packages/frontend/src/app/pages/profile/edit-profile/edit-profile.module.ts
+++ b/packages/frontend/src/app/pages/profile/edit-profile/edit-profile.module.ts
@@ -15,6 +15,7 @@ import { MatExpansionModule } from '@angular/material/expansion'
 import { TranslateModule } from '@ngx-translate/core'
 import { UserSelectorComponent } from 'src/app/components/user-selector/user-selector.component'
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner'
+import { FontAwesomeModule } from '@fortawesome/angular-fontawesome'
 
 const routes: Routes = [
   {
@@ -41,7 +42,8 @@ const routes: Routes = [
     TranslateModule,
     MatTabsModule,
     UserSelectorComponent,
-    MatProgressSpinnerModule
+    MatProgressSpinnerModule,
+    FontAwesomeModule
   ]
 })
 export class EditProfileModule {}

--- a/packages/frontend/src/app/pages/profile/edit-profile/edit-profile.module.ts
+++ b/packages/frontend/src/app/pages/profile/edit-profile/edit-profile.module.ts
@@ -14,6 +14,7 @@ import { EmojiCollectionsComponent } from 'src/app/components/emoji-collections/
 import { MatExpansionModule } from '@angular/material/expansion'
 import { TranslateModule } from '@ngx-translate/core'
 import { UserSelectorComponent } from 'src/app/components/user-selector/user-selector.component'
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner'
 
 const routes: Routes = [
   {
@@ -39,7 +40,8 @@ const routes: Routes = [
     MatExpansionModule,
     TranslateModule,
     MatTabsModule,
-    UserSelectorComponent
+    UserSelectorComponent,
+    MatProgressSpinnerModule
   ]
 })
 export class EditProfileModule {}

--- a/packages/frontend/src/assets/i18n/en.json
+++ b/packages/frontend/src/assets/i18n/en.json
@@ -106,6 +106,7 @@
       "changeDisplayName": "Display name (can contain emoji codes)",
       "changeBio": "Your bio/description. You can put emoji codes here too. You can use markdown here",
       "extraInfoHead": "Extra information (Fediverse exclusive)",
+      "addAttachment": "Add attachment",
       "fieldPropertyName": "Property name",
       "fieldPropertyValue": "Property value"
     },


### PR DESCRIPTION
Changes the Update Preferences button to disable while it loads, fixes preference tag preview styles, improves fediverse attachments, and hides the Update Preference button when it doesn't make sense to show it.

## Tag previews

before

<img width="194" height="58" alt="image" src="https://github.com/user-attachments/assets/ab51c351-659d-468b-b451-524353c5fb18" />

after

<img width="194" height="58" alt="image" src="https://github.com/user-attachments/assets/8b6ac145-8f86-4e9f-853f-fa2d996b3dab" />

## Update Preference button

it has a loader wow

<img width="777" height="97" alt="image" src="https://github.com/user-attachments/assets/298f70a4-0e11-4ff2-a018-2025d273b8a0" />

hides when it shouldn't really be visible

<img width="794" height="294" alt="image" src="https://github.com/user-attachments/assets/d6129b71-2806-43eb-9cc9-403a44beb155" />

## Fediverse Attachments

before

<img width="793" height="497" alt="image" src="https://github.com/user-attachments/assets/eb268a34-020f-47d8-a548-f331c93be00d" />

after

<img width="835" height="527" alt="image" src="https://github.com/user-attachments/assets/ba18203f-a7a8-4d20-8917-4998a03ff09f" />