### PR TITLE
fix: out of posts box styling

### DIFF
--- a/packages/frontend/src/app/pages/dashboard/dashboard.component.html
+++ b/packages/frontend/src/app/pages/dashboard/dashboard.component.html
@@ -11,12 +11,12 @@
 }
 
 @if (noMorePosts) {
-  <mat-card class="mx-3 lg:mx-4 wafrn-container">
+  <mat-card class="p-3 mb-6 lg:mx-4 wafrn-container">
     <h2>You dont seem to be following anyone yet!</h2>
-    <h3>
+    <p>
       Consider taking a look at the <a [routerLink]="'/dashboard/exploreLocal'">local dashboard</a> or
       <a [routerLink]="'/dashboard/explore'">explore the fediverse</a>
-    </h3>
+    </p>
   </mat-card>
 }
 


### PR DESCRIPTION
fixes the Out of Posts text. Header size will be fixed as of the related pull

## Before

<img width="792" height="261" alt="image" src="https://github.com/user-attachments/assets/1536b98c-3ffd-4b6a-841a-82422c9c94a1" />

## After

<img width="792" height="218" alt="image" src="https://github.com/user-attachments/assets/b0fca20b-b84a-44db-ae81-2e29e2c6bfdf" />

wowza