### PR TITLE
Smaller headers

### DIFF
--- a/packages/frontend/src/app/components/post-fragment/post-fragment.component.html
+++ b/packages/frontend/src/app/components/post-fragment/post-fragment.component.html
@@ -1,6 +1,6 @@
 <div [ngClass]="{ 'post-contains-muted-words': !!fragment().muted_words_cw && !showSensitiveContent() }">
   @if (fragment().title) {
-    <h3 [innerText]="fragment().title && !showSensitiveContent()"></h3>
+    <h1 [innerText]="fragment().title && !showSensitiveContent()"></h1>
   }
   @if (fragment().ask) {
     <app-single-ask [ask]="fragment().ask!"></app-single-ask>

--- a/packages/frontend/src/app/pages/admin/emoji-uploader/emoji-uploader.component.html
+++ b/packages/frontend/src/app/pages/admin/emoji-uploader/emoji-uploader.component.html
@@ -1,5 +1,5 @@
 <mat-card class="p-3 m-2 mb-6 lg:mx-4 scalein wafrn-container">
-  <h3>Upload emoji or emoji collection</h3>
+  <h2>Upload emoji or emoji collection</h2>
   <h4>This page is a WIP for internal use! Just me using it for now so sorry this is ugly lol</h4>
   <app-file-upload
     [config]="{

--- a/packages/frontend/src/app/pages/ask-list/ask-list.component.html
+++ b/packages/frontend/src/app/pages/ask-list/ask-list.component.html
@@ -1,5 +1,5 @@
 <div class="wafrn-container mx-1 md:mx-4">
-  <h3 class="m-0 text-2xl asks-text">Unanswered asks</h3>
+  <h2 class="m-0 text-2xl asks-text">Unanswered asks</h2>
 </div>
 @if (loading) {
   <app-loader>posts</app-loader>

--- a/packages/frontend/src/app/pages/dashboard/dashboard.component.html
+++ b/packages/frontend/src/app/pages/dashboard/dashboard.component.html
@@ -1,6 +1,6 @@
 @if (title) {
   <div class="mx-3 lg:mx-4 wafrn-container">
-    <h3 class="mb-2 text-3xl dashboard-title">{{ title }}</h3>
+    <h2 class="mb-2 text-3xl dashboard-title">{{ title }}</h2>
   </div>
 }
 @for (post of posts; track $index) {

--- a/packages/frontend/src/app/pages/mfa-setup/mfa-setup.component.html
+++ b/packages/frontend/src/app/pages/mfa-setup/mfa-setup.component.html
@@ -1,5 +1,5 @@
 <div class="mx-2 lg:mx-4 wafrn-container">
-  <h3 class="flex-grow-1 m-0 mb-2 text-2xl notifications-text">{{ 'profile.security.mfa.header' | translate }}</h3>
+  <h2 class="flex-grow-1 m-0 mb-2 text-2xl notifications-text">{{ 'profile.security.mfa.header' | translate }}</h2>
 </div>
 
 <mat-card class="p-3 mb-6 lg:mx-4 wafrn-container">

--- a/packages/frontend/src/app/pages/notifications/notifications.component.html
+++ b/packages/frontend/src/app/pages/notifications/notifications.component.html
@@ -1,5 +1,5 @@
 <div class="mx-2 lg:mx-4 wafrn-container">
-  <h3 class="flex-grow-1 m-0 mb-2 text-2xl notifications-text">Notifications</h3>
+  <h2 class="flex-grow-1 m-0 mb-2 text-2xl notifications-text">Notifications</h2>
 </div>
 
 @for (notification of notificationsToShow; track $index) {

--- a/packages/frontend/src/app/pages/profile/edit-profile/edit-profile.component.html
+++ b/packages/frontend/src/app/pages/profile/edit-profile/edit-profile.component.html
@@ -56,7 +56,7 @@
         <div [hidden]="loading" (click)="addFediAttachment()">+</div>
       </mat-tab>
       <mat-tab label="{{ 'profile.tabHeaders.preferences' | translate }}">
-        <h5 class="w-full">{{ 'profile.preferences.notificationFilters' | translate }}</h5>
+        <h2 class="preference-subheader">{{ 'profile.preferences.notificationFilters' | translate }}</h2>
         <mat-form-field class="w-full">
           <mat-label>{{ 'profile.preferences.showNotificationsFrom' | translate }}</mat-label>
           <mat-select formControlName="showNotificationsFrom">
@@ -161,7 +161,7 @@
         </mat-accordion>
       </mat-tab>
       <mat-tab label="{{ 'profile.tabHeaders.privacySecurity' | translate }}">
-        <p>Options</p>
+        <h2 class="preference-subheader">Options</h2>
         <mat-form-field class="w-full" appearance="outline">
           <mat-label>{{ 'profile.privacy.defaultPostPrivacy' | translate }}</mat-label>
           <mat-select [required]="true" formControlName="defaultPostEditorPrivacy">

--- a/packages/frontend/src/app/pages/profile/edit-profile/edit-profile.component.scss
+++ b/packages/frontend/src/app/pages/profile/edit-profile/edit-profile.component.scss
@@ -1,0 +1,3 @@
+.preference-subheader {
+  margin-bottom: 1rem;
+}

--- a/packages/frontend/src/app/styles/material-overrides.scss
+++ b/packages/frontend/src/app/styles/material-overrides.scss
@@ -18,3 +18,32 @@
 :root {
   --mat-list-list-item-one-line-container-height: 2rem;
 }
+
+// Basic element adjustments
+
+:root .mat-typography {
+  h1 {
+    font-size: 2rem;
+    line-height: 1.125;
+  }
+  h2 {
+    font-size: 1.625rem;
+    line-height: 1.125;
+  }
+  h3 {
+    font-size: 1.25rem;
+    line-height: 1.125;
+  }
+  h4 {
+    font-size: 1.15rem;
+    line-height: 1.125;
+  }
+  h5 {
+    font-size: 1rem;
+    line-height: 1.125;
+  }
+  h6 {
+    font-size: 0.875rem;
+    line-height: 1.125;
+  }
+}


### PR DESCRIPTION
Changes header sizes to be smaller and fixes semantic headers all over.

h1-4 are larger than regular text, h5 is the same, and h6 is smaller. All of them also have header font settings so h5 isn't actually the exact same.

## Before

how

<img width="792" height="938" alt="image" src="https://github.com/user-attachments/assets/c377a1c6-d3dc-4913-98b4-bffce8488fd7" />

semantically incorrect!!

<img width="841" height="93" alt="image" src="https://github.com/user-attachments/assets/0b3dd669-9a5f-4c06-9500-a0fed684766f" />

## After

actually readable wow

<img width="792" height="690" alt="image" src="https://github.com/user-attachments/assets/78e878e1-00d5-4c0b-92ff-6d3d27018797" />

looks basically the same but is more semantic

<img width="841" height="93" alt="image" src="https://github.com/user-attachments/assets/ca971ae3-5463-42f6-82f1-6b13a799ea21" />
