### PR TITLE
Fix emojis oops

### DIFF
--- a/packages/frontend/src/app/components/emoji-collections/emoji-collections.component.html
+++ b/packages/frontend/src/app/components/emoji-collections/emoji-collections.component.html
@@ -12,7 +12,7 @@
         [class.emoji-active-collection]="this.collectionHas(-2)"
         (click)="this.toggleCollection(-2)"
       >
-        <span><fa-icon title="Recent emojis" [icon]="clockIcon"></fa-icon></span>
+        <span><fa-icon title="Recent emojis" [icon]="clockIcon" class="vertical-align-middle"></fa-icon></span>
       </button>
       @for (emojiCollection of emojiCollections; track $index) {
         @if (emojiCollection.emojis.length > 0) {

--- a/packages/frontend/src/app/components/emoji-collections/emoji-collections.component.scss
+++ b/packages/frontend/src/app/components/emoji-collections/emoji-collections.component.scss
@@ -33,6 +33,7 @@ $narrow: 800px;
   display: flex;
   flex-direction: column;
   row-gap: 5px;
+  padding-bottom: 5px; // For overflow
 }
 
 .emoji-row {
@@ -66,14 +67,11 @@ $narrow: 800px;
 }
 
 .emoji-sidebar {
-  padding-left: 0.2rem;
-  padding-right: 0.2rem;
+  padding: 0.25rem;
   height: 400px;
   overflow-x: hidden;
   overflow-y: scroll;
   text-align: center;
-  align-items: center;
-  row-gap: 0.5rem;
   background-color: var(--mat-sys-surface-container-highest);
 
   @media (max-width: $narrow) {
@@ -88,6 +86,8 @@ $narrow: 800px;
     right: 0;
     background-color: var(--mat-sys-surface);
     z-index: 99;
+    column-gap: 0.5rem;
+    padding-inline: 0.75rem;
   }
 }
 

--- a/packages/frontend/src/app/components/emoji-collections/emoji-collections.component.scss
+++ b/packages/frontend/src/app/components/emoji-collections/emoji-collections.component.scss
@@ -69,7 +69,6 @@ $narrow: 800px;
   padding-left: 0.2rem;
   padding-right: 0.2rem;
   height: 400px;
-  flex-direction: column;
   overflow-x: hidden;
   overflow-y: scroll;
   text-align: center;
@@ -78,6 +77,7 @@ $narrow: 800px;
   background-color: var(--mat-sys-surface-container-highest);
 
   @media (max-width: $narrow) {
+    display: flex;
     flex-direction: row;
     height: 64px;
     overflow-y: hidden;

--- a/packages/frontend/src/app/components/emoji-collections/emoji-collections.component.ts
+++ b/packages/frontend/src/app/components/emoji-collections/emoji-collections.component.ts
@@ -114,7 +114,8 @@ export class EmojiCollectionsComponent implements AfterViewInit, OnDestroy {
   filterText = model<string>('')
 
   rowIterable = computed<AngularFor>(() => {
-    return new AngularFor(this.emojiPerRow() - 1)
+    const emojiModifier = window.innerWidth < this.narrow ? 0 : -1
+    return new AngularFor(this.emojiPerRow() + emojiModifier)
   })
 
   copyIcon = faCopy


### PR DESCRIPTION
Fixes the mobile bar. Whoops!

Also fixes up some paddings and fills out the emoji a bit while I'm at it.

## Before

<img width="427" height="902" alt="image" src="https://github.com/user-attachments/assets/4c53c032-495a-42ad-9192-7f39480d3ff5" />

no pixels

<img width="95" height="89" alt="image" src="https://github.com/user-attachments/assets/727362d3-0b23-4971-9ead-c25a5da68b0f" />

## After

<img width="427" height="902" alt="image" src="https://github.com/user-attachments/assets/9306d80a-6cb7-4d65-8f00-e32b01397cd7" />

8 pixels

<img width="95" height="89" alt="image" src="https://github.com/user-attachments/assets/70c035e8-b8cc-4270-bfac-c86f92f782f3" />
