### PR TITLE
Improve theme editor

### DIFF
--- a/packages/frontend/src/app/pages/profile/css-editor/css-editor.component.html
+++ b/packages/frontend/src/app/pages/profile/css-editor/css-editor.component.html
@@ -1,21 +1,23 @@
 <mat-card class="p-3 mb-6 lg:mx-4 wafrn-container">
-  <h2>Theme Editor</h2>
+  <h2>{{ 'theme-editor.title' | translate }}</h2>
   <p>
-    You can see a base template and some advice
-    <a href="https://github.com/gabboman/wafrn/blob/main/THEMING.md" target="_blank">in this guide</a>
+    {{ 'theme-editor.templateNote' | translate }}
+    <a href="https://github.com/gabboman/wafrn/blob/main/THEMING.md" target="_blank">{{
+      'theme-editor.themeGuideName' | translate
+    }}</a>
   </p>
   <mat-form-field class="w-full">
-    <mat-label>Edit your CSS theme</mat-label>
+    <mat-label>{{ 'theme-editor.themeTextLabel' | translate }}</mat-label>
     <textarea
       style="min-height: 50vh"
       matInput
-      placeholder="Write down your own css..."
+      placeholder="{{ 'theme-editor.themeTextLabel' | translate }}"
       [(ngModel)]="myCSS"
       [disabled]="!ready"
     >
     </textarea>
   </mat-form-field>
   <button mat-flat-button color="primary" (click)="submit()" class="w-full" [disabled]="!ready">
-    Update your theme
+    {{ 'theme-editor.updateButton' | translate }}
   </button>
 </mat-card>

--- a/packages/frontend/src/app/pages/profile/css-editor/css-editor.component.html
+++ b/packages/frontend/src/app/pages/profile/css-editor/css-editor.component.html
@@ -8,7 +8,7 @@
     <textarea style="min-height: 50vh" matInput placeholder="Write down your own css..." [(ngModel)]="myCSS">
     </textarea>
   </mat-form-field>
-  @if (ready) {
-    <button mat-flat-button color="primary" (click)="submit()" class="w-full">Update your theme</button>
-  }
+  <button mat-flat-button color="primary" (click)="submit()" class="w-full" [disabled]="!ready">
+    Update your theme
+  </button>
 </mat-card>

--- a/packages/frontend/src/app/pages/profile/css-editor/css-editor.component.html
+++ b/packages/frontend/src/app/pages/profile/css-editor/css-editor.component.html
@@ -1,8 +1,9 @@
 <mat-card class="p-3 mb-6 lg:mx-4 wafrn-container">
-  <h2>
+  <h2>Theme Editor</h2>
+  <p>
     You can see a base template and some advice
     <a href="https://github.com/gabboman/wafrn/blob/main/THEMING.md" target="_blank">in this guide</a>
-  </h2>
+  </p>
   <mat-form-field class="w-full">
     <mat-label>Edit your CSS theme</mat-label>
     <textarea

--- a/packages/frontend/src/app/pages/profile/css-editor/css-editor.component.html
+++ b/packages/frontend/src/app/pages/profile/css-editor/css-editor.component.html
@@ -5,7 +5,13 @@
   </h2>
   <mat-form-field class="w-full">
     <mat-label>Edit your CSS theme</mat-label>
-    <textarea style="min-height: 50vh" matInput placeholder="Write down your own css..." [(ngModel)]="myCSS">
+    <textarea
+      style="min-height: 50vh"
+      matInput
+      placeholder="Write down your own css..."
+      [(ngModel)]="myCSS"
+      [disabled]="!ready"
+    >
     </textarea>
   </mat-form-field>
   <button mat-flat-button color="primary" (click)="submit()" class="w-full" [disabled]="!ready">

--- a/packages/frontend/src/app/pages/profile/css-editor/css-editor.component.ts
+++ b/packages/frontend/src/app/pages/profile/css-editor/css-editor.component.ts
@@ -36,7 +36,7 @@ export class CssEditorComponent {
   submit() {
     this.ready = false
     this.themeService
-      .updateTheme(this.myCSS)
+      .updateTheme(this.myCSS || ' ') // Backend doesn't like empty strings
       .then(() => {
         this.ready = true
         this.messages.add({

--- a/packages/frontend/src/app/pages/profile/css-editor/css-editor.component.ts
+++ b/packages/frontend/src/app/pages/profile/css-editor/css-editor.component.ts
@@ -4,12 +4,13 @@ import { MatButtonModule } from '@angular/material/button'
 import { MatCardModule } from '@angular/material/card'
 import { MatInputModule } from '@angular/material/input'
 import { Router } from '@angular/router'
+import { TranslateModule } from '@ngx-translate/core'
 import { MessageService } from 'src/app/services/message.service'
 import { ThemeService } from 'src/app/services/theme.service'
 
 @Component({
   selector: 'app-css-editor',
-  imports: [MatCardModule, FormsModule, MatInputModule, MatButtonModule],
+  imports: [MatCardModule, FormsModule, MatInputModule, MatButtonModule, TranslateModule],
   templateUrl: './css-editor.component.html',
   styleUrl: './css-editor.component.scss'
 })

--- a/packages/frontend/src/app/pages/profile/css-editor/css-editor.component.ts
+++ b/packages/frontend/src/app/pages/profile/css-editor/css-editor.component.ts
@@ -24,7 +24,7 @@ export class CssEditorComponent {
     this.themeService
       .getMyThemeAsSting()
       .then((theme) => {
-        this.myCSS = theme
+        this.myCSS = theme.trim()
         this.ready = true
       })
       .catch((error) => {

--- a/packages/frontend/src/assets/i18n/en.json
+++ b/packages/frontend/src/assets/i18n/en.json
@@ -70,6 +70,14 @@
       "awaitingAproval": "Awaiting approval"
     }
   },
+  "theme-editor": {
+    "title": "Theme Editor",
+    "templateNote": "You can see a base template and some advice in the",
+    "themeTextLabel": "Edit your CSS theme",
+    "themeTextPlaceholder": "Write down your own css...",
+    "themeGuideName": "Theme Guide",
+    "updateButton": "Update Theme"
+  },
   "editor": {
     "inReplyTo": "In reply to:",
     "quoteButton": "Quote a woot",


### PR DESCRIPTION
Fixes #264 by making blank inputs just upload a single space secretly. Also improves a bit of the UX and adds translations as a treat.

## Before

<img width="777" height="681" alt="image" src="https://github.com/user-attachments/assets/15784d73-68bf-4e33-be76-a2def362ccac" />

Loading

<img width="791" height="150" alt="image" src="https://github.com/user-attachments/assets/43324e59-4265-49be-ba50-5229705843d6" />

lmao it's gone

## After

<img width="791" height="721" alt="image" src="https://github.com/user-attachments/assets/bb88fcad-cada-43c3-81f9-715e82091d23" />

Loading

<img width="791" height="150" alt="image" src="https://github.com/user-attachments/assets/3a309e34-01f6-470e-b17b-a53173448afe" />
