### PR TITLE
Improve theme experience amazing

### DIFF
--- a/packages/frontend/src/app/app.component.html
+++ b/packages/frontend/src/app/app.component.html
@@ -1,1 +1,2 @@
+<app-theme-manager></app-theme-manager>
 <router-outlet></router-outlet>

--- a/packages/frontend/src/app/app.module.ts
+++ b/packages/frontend/src/app/app.module.ts
@@ -14,6 +14,7 @@ import { MatSnackBarModule } from '@angular/material/snack-bar'
 import { TranslateHttpLoader } from '@ngx-translate/http-loader'
 import { TranslateLoader, TranslateModule } from '@ngx-translate/core'
 import { HttpClient } from '@angular/common/http'
+import { ThemeManagerComponent } from './theme-manager/theme-manager.component'
 
 const globalRippleConfig: RippleGlobalOptions = {
   disabled: true,
@@ -48,7 +49,8 @@ const globalRippleConfig: RippleGlobalOptions = {
         useFactory: HttpLoaderFactory,
         deps: [HttpClient]
       }
-    })
+    }),
+    ThemeManagerComponent
   ],
   providers: [
     provideHttpClient(withInterceptorsFromDi()),

--- a/packages/frontend/src/app/components/color-scheme-switcher/color-scheme-switcher.component.html
+++ b/packages/frontend/src/app/components/color-scheme-switcher/color-scheme-switcher.component.html
@@ -35,14 +35,14 @@
   </svg>
 </button>
 <mat-menu #themeMenu="matMenu">
-  @for (themeItem of colorThemeOrder; track $index) {
+  @for (entry of colorThemeData | keyvalue: null; track entry.key) {
     <button
       class="theme-selector-button"
-      [class.selected]="theme() === themeItem[0]"
+      [class.selected]="theme() === entry.key"
       mat-menu-item
-      (click)="setTheme(themeItem[0])"
+      (click)="setTheme(entry.key)"
     >
-      {{ themeItem[1] }}
+      {{ entry.value }}
     </button>
   }
 </mat-menu>
@@ -58,70 +58,32 @@
   <fa-icon [icon]="paletteIcon"></fa-icon>
 </button>
 <mat-menu #colorSchemeMenu="matMenu">
-  <button mat-menu-item [matMenuTriggerFor]="defaultThemesMenu">Default theme variants</button>
-  <button mat-menu-item [matMenuTriggerFor]="computeryThemesMenu">Computery themes</button>
-  <button mat-menu-item [matMenuTriggerFor]="experimentalThemesMenu">Experimental themes</button>
-  <button mat-menu-item [matMenuTriggerFor]="programmerThemesMenu">Programmer's favourites</button>
-
+  @for (group of colorSchemeGroupList | keyvalue: null; track group.key) {
+    <button mat-menu-item [matMenuTriggerFor]="secondaryThemesMenu" [matMenuTriggerData]="group.value">
+      {{ group.value.name }}
+    </button>
+  }
   <hr class="my-0" />
-
-  @for (entry of additionalStyleModesOrder; track $index) {
+  @for (entry of additionalStyleModes | keyvalue: null; track entry.key) {
     <button mat-menu-item class="pl-1">
-      <mat-checkbox [checked]="entry[1]()" (click)="toggleAdditionalStyleMode(entry[0])"
-        ><span class="theme-selector-button">{{ additionalStyleModesData[entry[0]].name }}</span></mat-checkbox
+      <mat-checkbox [checked]="entry.value()" (click)="toggleAdditionalStyleMode(entry.key)"
+        ><span class="theme-selector-button">{{ $any(additionalStyleModesData)[entry.key].name }}</span></mat-checkbox
       >
     </button>
   }
 </mat-menu>
 
-<mat-menu #defaultThemesMenu="matMenu">
-  @for (variant of defaultThemes; track $index) {
-    <button
-      class="theme-selector-button"
-      mat-menu-item
-      (click)="setColorScheme(variant)"
-      [class.selected]="colorScheme() === variant"
-    >
-      {{ colorSchemeData[variant].name }}
-    </button>
-  }
-</mat-menu>
-
-<mat-menu #computeryThemesMenu="matMenu">
-  @for (variant of computeryThemes; track $index) {
-    <button
-      class="theme-selector-button"
-      mat-menu-item
-      (click)="setColorScheme(variant)"
-      [class.selected]="colorScheme() === variant"
-    >
-      {{ colorSchemeData[variant].name }}
-    </button>
-  }
-</mat-menu>
-
-<mat-menu #experimentalThemesMenu="matMenu">
-  @for (variant of experimentalThemes; track $index) {
-    <button
-      class="theme-selector-button"
-      mat-menu-item
-      (click)="setColorScheme(variant)"
-      [class.selected]="colorScheme() === variant"
-    >
-      {{ colorSchemeData[variant].name }}
-    </button>
-  }
-</mat-menu>
-
-<mat-menu #programmerThemesMenu="matMenu">
-  @for (variant of programmersThemes; track $index) {
-    <button
-      class="theme-selector-button"
-      mat-menu-item
-      (click)="setColorScheme(variant)"
-      [class.selected]="colorScheme() === variant"
-    >
-      {{ colorSchemeData[variant].name }}
-    </button>
-  }
+<mat-menu #secondaryThemesMenu="matMenu">
+  <ng-template matMenuContent let-name="name" let-entries="entries">
+    @for (variant of entries; track $index) {
+      <button
+        class="theme-selector-button"
+        mat-menu-item
+        (click)="setColorScheme(variant)"
+        [class.selected]="colorScheme() === variant"
+      >
+        {{ $any(colorSchemeData)[variant].name }}
+      </button>
+    }
+  </ng-template>
 </mat-menu>

--- a/packages/frontend/src/app/components/color-scheme-switcher/color-scheme-switcher.component.html
+++ b/packages/frontend/src/app/components/color-scheme-switcher/color-scheme-switcher.component.html
@@ -5,7 +5,7 @@
   title="Change color scheme"
   aria-label="Change color scheme"
   [ngClass]="iconClass"
-  matTooltip="{{ themeText() }} mode"
+  matTooltip="{{ colorThemeData[theme()] }} mode"
 >
   <svg
     xmlns="http://www.w3.org/2000/svg"
@@ -35,9 +35,16 @@
   </svg>
 </button>
 <mat-menu #themeMenu="matMenu">
-  <button class="theme-selector-button" mat-menu-item (click)="setTheme('light', true)">Light</button>
-  <button class="theme-selector-button" mat-menu-item (click)="setTheme('dark', true)">Dark</button>
-  <button class="theme-selector-button" mat-menu-item (click)="setTheme('auto', true)">Auto</button>
+  @for (themeItem of colorThemeOrder; track $index) {
+    <button
+      class="theme-selector-button"
+      [class.selected]="theme() === themeItem[0]"
+      mat-menu-item
+      (click)="setTheme(themeItem[0])"
+    >
+      {{ themeItem[1] }}
+    </button>
+  }
 </mat-menu>
 
 <button
@@ -46,7 +53,7 @@
   class="theme-toggle"
   title="Toggle theme"
   aria-label="Toggle theme"
-  matTooltip="{{ colorSchemeText() }} theme"
+  matTooltip="{{ colorSchemeData[colorScheme()].name }} theme"
 >
   <fa-icon [icon]="paletteIcon"></fa-icon>
 </button>
@@ -57,21 +64,14 @@
   <button mat-menu-item [matMenuTriggerFor]="programmerThemesMenu">Programmer's favourites</button>
 
   <hr class="my-0" />
-  <button mat-menu-item class="pl-1">
-    <mat-checkbox [checked]="centerLayoutMode" (click)="updateCenterLayout(true)"
-      ><span class="theme-selector-button">Center layout</span></mat-checkbox
-    >
-  </button>
-  <button mat-menu-item class="pl-1">
-    <mat-checkbox [checked]="topToolbarMode" (click)="updateTopToolbar(true)"
-      ><span class="theme-selector-button">Top Toolbar</span></mat-checkbox
-    >
-  </button>
-  <button mat-menu-item class="pl-1">
-    <mat-checkbox [checked]="horizontalMenuMode" (click)="updateHorizontalMenu(true)"
-      ><span class="theme-selector-button">Horizontal Menu</span></mat-checkbox
-    >
-  </button>
+
+  @for (entry of additionalStyleModesOrder; track $index) {
+    <button mat-menu-item class="pl-1">
+      <mat-checkbox [checked]="entry[1]()" (click)="toggleAdditionalStyleMode(entry[0])"
+        ><span class="theme-selector-button">{{ additionalStyleModesData[entry[0]].name }}</span></mat-checkbox
+      >
+    </button>
+  }
 </mat-menu>
 
 <mat-menu #defaultThemesMenu="matMenu">
@@ -79,10 +79,10 @@
     <button
       class="theme-selector-button"
       mat-menu-item
-      (click)="setColorScheme(variant, true)"
-      [ngClass]="{ selected: variant == colorScheme() }"
+      (click)="setColorScheme(variant)"
+      [class.selected]="colorScheme() === variant"
     >
-      {{ variant | titlecase }}
+      {{ colorSchemeData[variant].name }}
     </button>
   }
 </mat-menu>
@@ -92,10 +92,10 @@
     <button
       class="theme-selector-button"
       mat-menu-item
-      (click)="setColorScheme(variant, true)"
-      [ngClass]="{ selected: variant == colorScheme() }"
+      (click)="setColorScheme(variant)"
+      [class.selected]="colorScheme() === variant"
     >
-      {{ variant | titlecase }}
+      {{ colorSchemeData[variant].name }}
     </button>
   }
 </mat-menu>
@@ -105,10 +105,10 @@
     <button
       class="theme-selector-button"
       mat-menu-item
-      (click)="setColorScheme(variant, true)"
-      [ngClass]="{ selected: variant == colorScheme() }"
+      (click)="setColorScheme(variant)"
+      [class.selected]="colorScheme() === variant"
     >
-      {{ variant | titlecase }}
+      {{ colorSchemeData[variant].name }}
     </button>
   }
 </mat-menu>
@@ -118,78 +118,10 @@
     <button
       class="theme-selector-button"
       mat-menu-item
-      (click)="setColorScheme(variant, true)"
-      [ngClass]="{ selected: variant == colorScheme() }"
+      (click)="setColorScheme(variant)"
+      [class.selected]="colorScheme() === variant"
     >
-      {{ variant | titlecase }}
+      {{ colorSchemeData[variant].name }}
     </button>
   }
 </mat-menu>
-
-@switch (colorScheme()) {
-  @case ('default') {}
-  @case ('tan') {
-    <link href="/assets/themes/tan.css" rel="stylesheet" />
-  }
-  @case ('green') {
-    <link href="/assets/themes/green.css" rel="stylesheet" />
-  }
-  @case ('gold') {
-    <link href="/assets/themes/gold.css" rel="stylesheet" />
-  }
-  @case ('red') {
-    <link href="/assets/themes/red.css" rel="stylesheet" />
-  }
-  @case ('pink') {
-    <link href="/assets/themes/pink.css" rel="stylesheet" />
-  }
-  @case ('purple') {
-    <link href="/assets/themes/purple.css" rel="stylesheet" />
-  }
-  @case ('blue') {
-    <link href="/assets/themes/blue.css" rel="stylesheet" />
-  }
-  @case ('rizzler') {
-    <link href="/assets/themes/rizzler.css" rel="stylesheet" />
-  }
-  @case ('contrastWater') {
-    <link href="/assets/themes/contrastWater.css" rel="stylesheet" />
-  }
-  @case ('wafrn98') {
-    <link href="/assets/themes/wafrn98.css" rel="stylesheet" />
-  }
-  @case ('aqua') {
-    <link href="/assets/themes/aqua.css" rel="stylesheet" />
-  }
-  @case ('unwafrn') {
-    <link href="/assets/themes/unwafrn.css" rel="stylesheet" />
-  }
-  @case ('wafrnverse') {
-    <link href="/assets/themes/wafrnverse.css" rel="stylesheet" />
-  }
-  @case ('dracula') {
-    <link href="/assets/themes/dracula.css" rel="stylesheet" />
-  }
-  @case ('fan') {
-    <link href="/assets/themes/fan.css" rel="stylesheet" />
-  }
-  @case ('catppuccin_frappe') {
-    <link href="/assets/themes/catppuccin_frappe.css" rel="stylesheet" />
-  }
-  @case ('catppuccin_latte') {
-    <link href="/assets/themes/catppuccin_latte.css" rel="stylesheet" />
-  }
-  @case ('catppuccin_macchiato') {
-    <link href="/assets/themes/catppuccin_macchiato.css" rel="stylesheet" />
-  }
-  @case ('catppuccin_mocha') {
-    <link href="/assets/themes/catppuccin_mocha.css" rel="stylesheet" />
-  }
-}
-
-@if (centerLayoutMode) {
-  <link href="/assets/themes/center-column.css" rel="stylesheet" />
-}
-@if (topToolbarMode) {
-  <link href="/assets/themes/top-toolbar.css" rel="stylesheet" />
-}

--- a/packages/frontend/src/app/components/color-scheme-switcher/color-scheme-switcher.component.ts
+++ b/packages/frontend/src/app/components/color-scheme-switcher/color-scheme-switcher.component.ts
@@ -20,10 +20,7 @@ import {
 
 // !! NOTE FOR ADDING THEMES !! //
 //
-// Themes have been moved to theme-manager.component.ts though you will
-// have to add them into a category in this file to actually select them
-//
-// See theme-manager.component.ts for full instruction
+// Themes have been moved to theme-manager.component.ts and are now fully data!
 
 @Component({
   selector: 'app-color-scheme-switcher',

--- a/packages/frontend/src/app/components/color-scheme-switcher/color-scheme-switcher.component.ts
+++ b/packages/frontend/src/app/components/color-scheme-switcher/color-scheme-switcher.component.ts
@@ -1,18 +1,18 @@
 import { CommonModule, NgClass } from '@angular/common'
-import { Component, linkedSignal, Signal, signal, WritableSignal } from '@angular/core'
+import { Component, Signal, WritableSignal } from '@angular/core'
 import { MatButtonModule } from '@angular/material/button'
 import { MatCheckboxModule } from '@angular/material/checkbox'
 import { MatMenuModule } from '@angular/material/menu'
 import { MatTooltipModule } from '@angular/material/tooltip'
 import { FaIconComponent } from '@fortawesome/angular-fontawesome'
 import { faPalette } from '@fortawesome/free-solid-svg-icons'
-import { TranslateService } from '@ngx-translate/core'
-import { LoginService } from 'src/app/services/login.service'
 import {
   AdditionalStyleMode,
   additionalStyleModesData,
   ColorScheme,
   colorSchemeData,
+  colorSchemeGroupList,
+  ColorSchemeGroupList,
   ColorTheme,
   colorThemeData,
   ThemeService
@@ -47,9 +47,7 @@ export class ColorSchemeSwitcherComponent {
   // Data copies
   colorSchemeData = colorSchemeData
   colorThemeData = colorThemeData
-  colorThemeOrder = Object.entries(colorThemeData)
   additionalStyleModesData = additionalStyleModesData
-  additionalStyleModesOrder: [AdditionalStyleMode, WritableSignal<boolean>][]
 
   // Function copies
   setColorScheme: Function
@@ -57,16 +55,7 @@ export class ColorSchemeSwitcherComponent {
   toggleAdditionalStyleMode: Function
 
   // Theme categories
-  defaultThemes: ColorScheme[] = ['default', 'tan', 'green', 'gold', 'red', 'pink', 'purple', 'blue']
-  computeryThemes: ColorScheme[] = ['unwafrn', 'wafrnverse', 'wafrn98', 'aqua', 'fan']
-  experimentalThemes: ColorScheme[] = ['rizzler', 'contrastWater']
-  programmersThemes: ColorScheme[] = [
-    'dracula',
-    'catppuccin_latte',
-    'catppuccin_frappe',
-    'catppuccin_macchiato',
-    'catppuccin_mocha'
-  ]
+  colorSchemeGroupList: ColorSchemeGroupList
 
   // Icons
   paletteIcon = faPalette
@@ -78,14 +67,12 @@ export class ColorSchemeSwitcherComponent {
     this.colorScheme = themeService.colorScheme
     this.theme = themeService.theme
     this.additionalStyleModes = themeService.additionalStyleModes
-    this.additionalStyleModesOrder = Object.entries(this.additionalStyleModes) as [
-      AdditionalStyleMode,
-      WritableSignal<boolean>
-    ][]
 
     this.setColorScheme = themeService.setColorScheme.bind(themeService)
     this.setTheme = themeService.setTheme.bind(themeService)
     this.toggleAdditionalStyleMode = themeService.toggleAdditionalStyleMode.bind(themeService)
+
+    this.colorSchemeGroupList = colorSchemeGroupList
 
     window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', this.updateIconTheme.bind(this))
   }

--- a/packages/frontend/src/app/components/color-scheme-switcher/color-scheme-switcher.component.ts
+++ b/packages/frontend/src/app/components/color-scheme-switcher/color-scheme-switcher.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule, NgClass } from '@angular/common'
-import { Component, linkedSignal, signal } from '@angular/core'
+import { Component, linkedSignal, Signal, signal, WritableSignal } from '@angular/core'
 import { MatButtonModule } from '@angular/material/button'
 import { MatCheckboxModule } from '@angular/material/checkbox'
 import { MatMenuModule } from '@angular/material/menu'
@@ -8,53 +8,22 @@ import { FaIconComponent } from '@fortawesome/angular-fontawesome'
 import { faPalette } from '@fortawesome/free-solid-svg-icons'
 import { TranslateService } from '@ngx-translate/core'
 import { LoginService } from 'src/app/services/login.service'
+import {
+  AdditionalStyleMode,
+  additionalStyleModesData,
+  ColorScheme,
+  colorSchemeData,
+  ColorTheme,
+  colorThemeData,
+  ThemeService
+} from 'src/app/services/theme.service'
 
 // !! NOTE FOR ADDING THEMES !! //
 //
-// If you want to add a theme, you must:
-// - Update this type
-// - Add the theme as a CSS file in `/assets/themes/name.css`
-// - Add a link file to it in this component's HTML file
-
-const colorThemeVariants = ['light', 'dark', 'auto'] as const
-type ColorThemeTuple = typeof colorThemeVariants
-type ColorTheme = ColorThemeTuple[number]
-
-function isColorTheme(value: string): value is ColorTheme {
-  return colorThemeVariants.includes(value as ColorTheme)
-}
-function isColorScheme(value: string): value is ColorScheme {
-  return colorSchemeVariants.includes(value as ColorScheme)
-}
-const colorSchemeVariants = [
-  'default',
-  'tan',
-  'green',
-  'gold',
-  'red',
-  'pink',
-  'purple',
-  'blue',
-  'rizzler',
-  'contrastWater',
-  'wafrn98',
-  'aqua',
-  'unwafrn',
-  'wafrnverse',
-  'dracula',
-  'fan',
-  'catppuccin_frappe',
-  'catppuccin_latte',
-  'catppuccin_macchiato',
-  'catppuccin_mocha'
-] as const
-type ColorSchemeTuple = typeof colorSchemeVariants
-type ColorScheme = ColorSchemeTuple[number]
-
-function capitalize(text: string) {
-  text = text[0].toUpperCase() + text.slice(1)
-  return text
-}
+// Themes have been moved to theme-manager.component.ts though you will
+// have to add them into a category in this file to actually select them
+//
+// See theme-manager.component.ts for full instruction
 
 @Component({
   selector: 'app-color-scheme-switcher',
@@ -71,10 +40,23 @@ function capitalize(text: string) {
   styleUrl: './color-scheme-switcher.component.scss'
 })
 export class ColorSchemeSwitcherComponent {
-  // Utility
-  readonly variants = colorSchemeVariants
-  readonly capitalize = capitalize
+  colorScheme: Signal<ColorScheme>
+  theme: Signal<ColorTheme>
+  additionalStyleModes: { [key in AdditionalStyleMode]: WritableSignal<boolean> }
 
+  // Data copies
+  colorSchemeData = colorSchemeData
+  colorThemeData = colorThemeData
+  colorThemeOrder = Object.entries(colorThemeData)
+  additionalStyleModesData = additionalStyleModesData
+  additionalStyleModesOrder: [AdditionalStyleMode, WritableSignal<boolean>][]
+
+  // Function copies
+  setColorScheme: Function
+  setTheme: Function
+  toggleAdditionalStyleMode: Function
+
+  // Theme categories
   defaultThemes: ColorScheme[] = ['default', 'tan', 'green', 'gold', 'red', 'pink', 'purple', 'blue']
   computeryThemes: ColorScheme[] = ['unwafrn', 'wafrnverse', 'wafrn98', 'aqua', 'fan']
   experimentalThemes: ColorScheme[] = ['rizzler', 'contrastWater']
@@ -86,117 +68,26 @@ export class ColorSchemeSwitcherComponent {
     'catppuccin_mocha'
   ]
 
-  // Color scheme
-  colorScheme = signal<ColorScheme>('default')
-  colorSchemeText = linkedSignal(() => capitalize(this.colorScheme()))
-
-  // Options
-  centerLayoutMode = localStorage.getItem('centerLayout') === 'true'
-  topToolbarMode = localStorage.getItem('topToolbar') === 'true'
-  horizontalMenuMode = localStorage.getItem('horizontalMenu') === 'true'
-
   // Icons
   paletteIcon = faPalette
 
   // Light/Dark mode
-  theme = signal<ColorTheme>(this.getTheme())
-  themeText = linkedSignal(() => capitalize(this.theme()))
   iconClass = ''
 
-  constructor(
-    private loginService: LoginService,
-    private translateService: TranslateService
-  ) {
-    const colorScheme = localStorage.getItem('colorScheme')
-    if (
-      colorScheme !== null &&
-      colorScheme !== 'rizzler' &&
-      colorScheme !== 'contrastWater' &&
-      isColorScheme(colorScheme)
-    ) {
-      this.setColorScheme(colorScheme)
-    }
-    const chromeVersionForCompatibilityReasons = this.getChromeVersion()
-    if (chromeVersionForCompatibilityReasons) {
-      if (chromeVersionForCompatibilityReasons < 122) {
-        // we force the fan theme on old browsers
-        this.setColorScheme('fan')
-      }
-    }
-    this.setTheme(this.theme())
+  constructor(themeService: ThemeService) {
+    this.colorScheme = themeService.colorScheme
+    this.theme = themeService.theme
+    this.additionalStyleModes = themeService.additionalStyleModes
+    this.additionalStyleModesOrder = Object.entries(this.additionalStyleModes) as [
+      AdditionalStyleMode,
+      WritableSignal<boolean>
+    ][]
+
+    this.setColorScheme = themeService.setColorScheme.bind(themeService)
+    this.setTheme = themeService.setTheme.bind(themeService)
+    this.toggleAdditionalStyleMode = themeService.toggleAdditionalStyleMode.bind(themeService)
+
     window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', this.updateIconTheme.bind(this))
-  }
-
-  getColorScheme(): ColorScheme {
-    if (typeof localStorage !== 'undefined') {
-      const localScheme = localStorage.getItem('theme')
-      if (localScheme !== null && isColorScheme(localScheme)) {
-        return localScheme
-      }
-    }
-    return 'default'
-  }
-
-  async setColorScheme(scheme: ColorScheme, forceUpdate = false) {
-    this.colorScheme.set(scheme)
-    if (typeof localStorage !== 'undefined') {
-      localStorage.setItem('colorScheme', scheme)
-    }
-    const forceDarkModeThemes = ['wafrn98', 'unwafrn']
-    const forceLightModeThemes: string[] = []
-    if (forceDarkModeThemes.includes(scheme)) {
-      await this.setTheme('dark')
-    }
-    if (forceLightModeThemes.includes(scheme)) {
-      await this.setTheme('light')
-    }
-    if (forceUpdate && this.loginService.checkUserLoggedIn()) {
-      await this.loginService.updateUserOptions([{ name: 'wafrn.colorScheme', value: scheme }])
-    }
-  }
-
-  async updateCenterLayout(forceUpdate = false) {
-    this.centerLayoutMode = !this.centerLayoutMode
-    if (forceUpdate && this.loginService.checkUserLoggedIn()) {
-      await this.loginService.updateUserOptions([
-        { name: 'wafrn.centerLayout', value: this.centerLayoutMode.toString() }
-      ])
-    }
-  }
-
-  async updateTopToolbar(forceUpdate = false) {
-    this.topToolbarMode = !this.topToolbarMode
-    if (forceUpdate && this.loginService.checkUserLoggedIn()) {
-      await this.loginService.updateUserOptions([{ name: 'wafrn.topToolbar', value: this.topToolbarMode.toString() }])
-    }
-  }
-
-  async updateHorizontalMenu(forceUpdate = false) {
-    this.horizontalMenuMode = !this.horizontalMenuMode
-    if (forceUpdate) {
-      await this.loginService.updateUserOptions([
-        { name: 'wafrn.horizontalMenu', value: this.horizontalMenuMode.toString() }
-      ])
-    }
-  }
-
-  getTheme(): ColorTheme {
-    if (typeof localStorage !== 'undefined') {
-      const localTheme = localStorage.getItem('theme')
-      if (localTheme !== null && isColorTheme(localTheme)) {
-        return localTheme
-      }
-    }
-    return 'auto'
-  }
-
-  async setTheme(theme: ColorTheme, forceUpdate = false) {
-    this.theme.set(theme)
-    document.documentElement.setAttribute('data-theme', theme)
-    this.updateIconTheme()
-    if (forceUpdate) {
-      await this.loginService.updateUserOptions([{ name: 'wafrn.theme', value: theme }])
-    }
   }
 
   updateIconTheme() {
@@ -208,15 +99,5 @@ export class ColorSchemeSwitcherComponent {
     } else {
       this.iconClass = ''
     }
-  }
-
-  getChromeVersion() {
-    var raw = navigator.userAgent.match(/Chrom(e|ium)\/([0-9]+)\./)
-
-    return raw ? parseInt(raw[2], 10) : false
-  }
-
-  setLang(lang: string) {
-    this.translateService.setDefaultLang(lang)
   }
 }

--- a/packages/frontend/src/app/pages/profile/edit-profile/edit-profile.component.html
+++ b/packages/frontend/src/app/pages/profile/edit-profile/edit-profile.component.html
@@ -86,6 +86,36 @@
         </button>
       </mat-tab>
       <mat-tab label="{{ 'profile.tabHeaders.preferences' | translate }}">
+        <h2 class="preference-subheader">{{ 'profile.preferences.appearance' | translate }}</h2>
+        <mat-form-field class="w-full">
+          <mat-label>{{ 'profile.preferences.colorScheme' | translate }}</mat-label>
+          <mat-select [(value)]="colorSchemeSelect" (selectionChange)="syncColorScheme()">
+            @for (group of colorSchemeGroupList | keyvalue: null; track $index) {
+              <mat-optgroup [label]="group.value.name">
+                @for (entry of group.value.entries; track $index) {
+                  <mat-option [value]="entry">{{ colorSchemeData[entry].name }}</mat-option>
+                }
+              </mat-optgroup>
+            }
+          </mat-select>
+        </mat-form-field>
+        <mat-form-field class="w-full">
+          <mat-label>{{ 'profile.preferences.theme' | translate }}</mat-label>
+          <mat-select [(value)]="themeSelect" (selectionChange)="syncTheme()">
+            @for (entry of colorThemeData | keyvalue: null; track $index) {
+              <mat-option [value]="entry.key">{{ entry.value }}</mat-option>
+            }
+          </mat-select>
+        </mat-form-field>
+        <mat-form-field class="w-full">
+          <mat-label>{{ 'profile.preferences.additionalStyleModes' | translate }}</mat-label>
+          <mat-select [(value)]="additionalStyleModesSelect" (selectionChange)="syncAdditionalStyleModes()" multiple>
+            @for (entry of additionalStyleModesData | keyvalue: null; track $index) {
+              <mat-option [value]="entry.key">{{ entry.value.name }}</mat-option>
+            }
+          </mat-select>
+        </mat-form-field>
+        <hr />
         <h2 class="preference-subheader">{{ 'profile.preferences.notificationFilters' | translate }}</h2>
         <mat-form-field class="w-full">
           <mat-label>{{ 'profile.preferences.showNotificationsFrom' | translate }}</mat-label>

--- a/packages/frontend/src/app/pages/profile/edit-profile/edit-profile.component.ts
+++ b/packages/frontend/src/app/pages/profile/edit-profile/edit-profile.component.ts
@@ -11,6 +11,7 @@ import { MediaService } from 'src/app/services/media.service'
 import { MessageService } from 'src/app/services/message.service'
 import { ThemeService } from 'src/app/services/theme.service'
 import { faPlus, faXmark } from '@fortawesome/free-solid-svg-icons'
+import { ColorSchemeSwitcherComponent } from 'src/app/components/color-scheme-switcher/color-scheme-switcher.component'
 
 @Component({
   selector: 'app-edit-profile',
@@ -98,7 +99,7 @@ export class EditProfileComponent implements OnInit {
     private messages: MessageService,
     private themeService: ThemeService
   ) {
-    this.themeService.setTheme('')
+    this.themeService.setCustomCSS('')
   }
 
   ngOnInit(): void {

--- a/packages/frontend/src/app/pages/profile/edit-profile/edit-profile.component.ts
+++ b/packages/frontend/src/app/pages/profile/edit-profile/edit-profile.component.ts
@@ -9,9 +9,18 @@ import { JwtService } from 'src/app/services/jwt.service'
 import { LoginService } from 'src/app/services/login.service'
 import { MediaService } from 'src/app/services/media.service'
 import { MessageService } from 'src/app/services/message.service'
-import { ThemeService } from 'src/app/services/theme.service'
+import {
+  AdditionalStyleMode,
+  additionalStyleModesData,
+  ColorScheme,
+  colorSchemeData,
+  ColorSchemeGroupList,
+  colorSchemeGroupList,
+  ColorTheme,
+  colorThemeData,
+  ThemeService
+} from 'src/app/services/theme.service'
 import { faPlus, faXmark } from '@fortawesome/free-solid-svg-icons'
-import { ColorSchemeSwitcherComponent } from 'src/app/components/color-scheme-switcher/color-scheme-switcher.component'
 
 @Component({
   selector: 'app-edit-profile',
@@ -91,6 +100,26 @@ export class EditProfileComponent implements OnInit {
 
   password = ''
 
+  colorScheme: Signal<ColorScheme>
+  colorSchemeSelect = ''
+  theme: Signal<ColorTheme>
+  themeSelect = ''
+  additionalStyleModes: { [key in AdditionalStyleMode]: WritableSignal<boolean> }
+  additionalStyleModesSelect: AdditionalStyleMode[]
+
+  // Data copies
+  colorSchemeData = colorSchemeData
+  colorThemeData = colorThemeData
+  additionalStyleModesData = additionalStyleModesData
+
+  // Function copies
+  setColorScheme: Function
+  setTheme: Function
+  setAdditionalStyleMode: Function
+
+  // Theme categories
+  colorSchemeGroupList: ColorSchemeGroupList
+
   constructor(
     private jwtService: JwtService,
     private dashboardService: DashboardService,
@@ -99,7 +128,38 @@ export class EditProfileComponent implements OnInit {
     private messages: MessageService,
     private themeService: ThemeService
   ) {
+    this.colorScheme = themeService.colorScheme
+    this.colorSchemeSelect = this.colorScheme()
+    this.theme = themeService.theme
+    this.themeSelect = this.theme()
+    this.additionalStyleModes = themeService.additionalStyleModes
+    this.additionalStyleModesSelect = Object.entries(this.additionalStyleModes)
+      .filter(([_, enabled]) => enabled())
+      .map(([val, _]) => val) as AdditionalStyleMode[]
+
+    this.setColorScheme = themeService.setColorScheme.bind(themeService)
+    this.setTheme = themeService.setTheme.bind(themeService)
+    this.setAdditionalStyleMode = themeService.setAdditionalStyleMode.bind(themeService)
+
+    this.colorSchemeGroupList = colorSchemeGroupList
+
     this.themeService.setCustomCSS('')
+  }
+
+  syncColorScheme() {
+    this.setColorScheme(this.colorSchemeSelect)
+  }
+
+  syncTheme() {
+    this.setTheme(this.themeSelect)
+  }
+
+  syncAdditionalStyleModes() {
+    const allModes = Object.keys(this.additionalStyleModesData) as AdditionalStyleMode[]
+    const enabledModes = this.additionalStyleModesSelect
+    const disabledModes = allModes.filter((mode) => !this.additionalStyleModesSelect.includes(mode))
+    enabledModes.forEach((mode) => this.setAdditionalStyleMode(mode, true))
+    disabledModes.forEach((mode) => this.setAdditionalStyleMode(mode, false))
   }
 
   ngOnInit(): void {

--- a/packages/frontend/src/app/pages/view-blog/view-blog.component.ts
+++ b/packages/frontend/src/app/pages/view-blog/view-blog.component.ts
@@ -90,7 +90,7 @@ export class ViewBlogComponent implements OnInit, OnDestroy, SnappyHide, SnappyS
     if (this.userLoggedIn) {
       this.themeService.setMyTheme()
     } else {
-      this.themeService.setTheme('')
+      this.themeService.setCustomCSS('')
     }
   }
 
@@ -191,7 +191,7 @@ export class ViewBlogComponent implements OnInit, OnDestroy, SnappyHide, SnappyS
       let userResponseToCustomThemes = this.themeService.hasUserAcceptedCustomThemes()
 
       if (userResponseToCustomThemes === 2) {
-        this.themeService.setTheme(blogDetails.id)
+        this.themeService.setCustomCSS(blogDetails.id)
       }
 
       if (userResponseToCustomThemes === 0) {
@@ -201,12 +201,12 @@ export class ViewBlogComponent implements OnInit, OnDestroy, SnappyHide, SnappyS
         dialogRef.afterClosed().subscribe(() => {
           userResponseToCustomThemes = this.themeService.hasUserAcceptedCustomThemes()
           if (userResponseToCustomThemes === 2) {
-            this.themeService.setTheme(blogDetails.id)
+            this.themeService.setCustomCSS(blogDetails.id)
           }
         })
       }
     } else {
-      this.themeService.setTheme('')
+      this.themeService.setCustomCSS('')
     }
   }
 

--- a/packages/frontend/src/app/services/theme.service.ts
+++ b/packages/frontend/src/app/services/theme.service.ts
@@ -73,6 +73,40 @@ export const colorSchemeData: ColorSchemeData = {
   catppuccin_mocha: { name: 'Catppuccin Mocha', compatibility: 'both' }
 }
 
+const colorSchemeGroupVariants = [
+  'defaultThemes',
+  'computeryThemes',
+  'experimentalThemes',
+  'programmersThemes'
+] as const
+type ColorSchemeGroupTuple = typeof colorSchemeGroupVariants
+export type ColorSchemeGroup = ColorSchemeGroupTuple[number]
+export type ColorSchemeGroupList = {
+  [key in ColorSchemeGroup]: {
+    name: string
+    entries: ColorScheme[]
+  }
+}
+
+export const colorSchemeGroupList: ColorSchemeGroupList = {
+  defaultThemes: {
+    name: 'Default theme variants',
+    entries: ['default', 'tan', 'green', 'gold', 'red', 'pink', 'purple', 'blue']
+  },
+  computeryThemes: {
+    name: 'Computery themes',
+    entries: ['unwafrn', 'wafrnverse', 'wafrn98', 'aqua', 'fan']
+  },
+  experimentalThemes: {
+    name: 'Experimental themes',
+    entries: ['rizzler', 'contrastWater']
+  },
+  programmersThemes: {
+    name: "Programmer's Favourites",
+    entries: ['dracula', 'catppuccin_latte', 'catppuccin_frappe', 'catppuccin_macchiato', 'catppuccin_mocha']
+  }
+}
+
 const colorThemeVariants = ['light', 'dark', 'auto'] as const
 type ColorThemeTuple = typeof colorThemeVariants
 export type ColorTheme = ColorThemeTuple[number]

--- a/packages/frontend/src/app/services/theme.service.ts
+++ b/packages/frontend/src/app/services/theme.service.ts
@@ -7,16 +7,22 @@ import { EnvironmentService } from './environment.service'
 // !! NOTE FOR ADDING THEMES !! //
 //
 // If you want to add a theme, you must:
-// - Update the list colorSchemeVariants
-// - Fill out its colorSchemeData (name data and if the theme forces light/dark) entry
+// - Add it to `colorSchemeVariants`
+// - Fill out its `colorSchemeData` (name data and if the theme forces light/dark) entry
+//   - Compatibility allows you to force dark/light if you need.
+//   - Auto Reset makes the theme be reset to default on reload
 // - Add the theme as a CSS file in `/assets/themes/name.css`
-// - Add a link file to it in this component's HTML file
-//
-// Once you do this, the theme is now usable. To actually be able to select it,
-// navigate to color-scheme-switcher.component.ts and add it under one of the theme lists.
+// - Add a link file to it in theme-manager.component.html
+// - Add your theme to a group in `colorSchemeGroupList`
 
 // !! NOTE FOR ADDING MODES !! //
-// (like top toolbar mode)
+//
+// If you want to add a style mode, you must:
+// - Add it to `additionalStyleModeVariants`
+// - Fill out its `additionalStyleModesData`
+//
+// Note: This uses the raw names of the mode setting.
+// DO NOT OVERRIDE OTHER LOCAL STORAGE ENTRIES! There is no check :3
 
 const colorSchemeVariants = [
   'default',
@@ -50,6 +56,7 @@ type ColorSchemeData = {
     autoReset?: boolean
   }
 }
+
 export const colorSchemeData: ColorSchemeData = {
   default: { name: 'Default', compatibility: 'both' },
   tan: { name: 'Tan', compatibility: 'both' },

--- a/packages/frontend/src/app/services/theme.service.ts
+++ b/packages/frontend/src/app/services/theme.service.ts
@@ -209,14 +209,17 @@ export class ThemeService {
     await this.loginService.updateUserOptions([{ name: 'wafrn.theme', value: theme }])
   }
 
-  public async toggleAdditionalStyleMode(mode: AdditionalStyleMode, doNotSavePreference = false) {
-    this.additionalStyleModes[mode].update((val) => !val)
-    const modeEnabled = this.additionalStyleModes[mode]().toString()
-    localStorage?.setItem(mode, modeEnabled.toString())
+  public async setAdditionalStyleMode(mode: AdditionalStyleMode, value: boolean, doNotSavePreference = false) {
+    this.additionalStyleModes[mode].set(value)
+    localStorage?.setItem(mode, value.toString())
 
     // User settings
     if (doNotSavePreference) return
-    await this.loginService.updateUserOptions([{ name: `wafrn.${mode}`, value: modeEnabled }])
+    await this.loginService.updateUserOptions([{ name: `wafrn.${mode}`, value: value.toString() }])
+  }
+
+  public async toggleAdditionalStyleMode(mode: AdditionalStyleMode, doNotSavePreference = false) {
+    this.setAdditionalStyleMode(mode, !this.additionalStyleModes[mode](), doNotSavePreference)
   }
 
   getChromeVersion() {

--- a/packages/frontend/src/app/theme-manager/theme-manager.component.html
+++ b/packages/frontend/src/app/theme-manager/theme-manager.component.html
@@ -1,0 +1,67 @@
+@switch (colorScheme()) {
+  @case ('default') {}
+  @case ('tan') {
+    <link href="/assets/themes/tan.css" rel="stylesheet" />
+  }
+  @case ('green') {
+    <link href="/assets/themes/green.css" rel="stylesheet" />
+  }
+  @case ('gold') {
+    <link href="/assets/themes/gold.css" rel="stylesheet" />
+  }
+  @case ('red') {
+    <link href="/assets/themes/red.css" rel="stylesheet" />
+  }
+  @case ('pink') {
+    <link href="/assets/themes/pink.css" rel="stylesheet" />
+  }
+  @case ('purple') {
+    <link href="/assets/themes/purple.css" rel="stylesheet" />
+  }
+  @case ('blue') {
+    <link href="/assets/themes/blue.css" rel="stylesheet" />
+  }
+  @case ('rizzler') {
+    <link href="/assets/themes/rizzler.css" rel="stylesheet" />
+  }
+  @case ('contrastWater') {
+    <link href="/assets/themes/contrastWater.css" rel="stylesheet" />
+  }
+  @case ('wafrn98') {
+    <link href="/assets/themes/wafrn98.css" rel="stylesheet" />
+  }
+  @case ('aqua') {
+    <link href="/assets/themes/aqua.css" rel="stylesheet" />
+  }
+  @case ('unwafrn') {
+    <link href="/assets/themes/unwafrn.css" rel="stylesheet" />
+  }
+  @case ('wafrnverse') {
+    <link href="/assets/themes/wafrnverse.css" rel="stylesheet" />
+  }
+  @case ('dracula') {
+    <link href="/assets/themes/dracula.css" rel="stylesheet" />
+  }
+  @case ('fan') {
+    <link href="/assets/themes/fan.css" rel="stylesheet" />
+  }
+  @case ('catppuccin_frappe') {
+    <link href="/assets/themes/catppuccin_frappe.css" rel="stylesheet" />
+  }
+  @case ('catppuccin_latte') {
+    <link href="/assets/themes/catppuccin_latte.css" rel="stylesheet" />
+  }
+  @case ('catppuccin_macchiato') {
+    <link href="/assets/themes/catppuccin_macchiato.css" rel="stylesheet" />
+  }
+  @case ('catppuccin_mocha') {
+    <link href="/assets/themes/catppuccin_mocha.css" rel="stylesheet" />
+  }
+}
+
+@if (additionalStyleModes.centerLayout()) {
+  <link href="/assets/themes/center-column.css" rel="stylesheet" />
+}
+@if (additionalStyleModes.topToolbar()) {
+  <link href="/assets/themes/top-toolbar.css" rel="stylesheet" />
+}

--- a/packages/frontend/src/app/theme-manager/theme-manager.component.scss
+++ b/packages/frontend/src/app/theme-manager/theme-manager.component.scss
@@ -1,0 +1,3 @@
+:host {
+  display: none;
+}

--- a/packages/frontend/src/app/theme-manager/theme-manager.component.ts
+++ b/packages/frontend/src/app/theme-manager/theme-manager.component.ts
@@ -1,0 +1,20 @@
+import { Component, Signal, WritableSignal } from '@angular/core'
+import { AdditionalStyleMode, ColorScheme, ColorTheme, ThemeService } from '../services/theme.service'
+
+@Component({
+  selector: 'app-theme-manager',
+  imports: [],
+  templateUrl: './theme-manager.component.html',
+  styleUrl: './theme-manager.component.scss'
+})
+export class ThemeManagerComponent {
+  colorScheme: Signal<ColorScheme>
+  theme: Signal<ColorTheme>
+  additionalStyleModes: { [key in AdditionalStyleMode]: WritableSignal<boolean> }
+
+  constructor(themeService: ThemeService) {
+    this.colorScheme = themeService.colorScheme
+    this.theme = themeService.theme
+    this.additionalStyleModes = themeService.additionalStyleModes
+  }
+}

--- a/packages/frontend/src/assets/i18n/en.json
+++ b/packages/frontend/src/assets/i18n/en.json
@@ -123,6 +123,10 @@
       "fieldPropertyValue": "Property value"
     },
     "preferences": {
+      "appearance": "Appearance",
+      "colorScheme": "Color Scheme",
+      "theme": "Theme",
+      "additionalStyleModes": "Additional Style Modes",
       "notificationFilters": "Notification filtering",
       "showNotificationsFrom": "Show notifications from",
       "notifyFrom": {


### PR DESCRIPTION
Reworks how themes work by a lot to allow for theme settings in preferences. Also makes future translation of theme names a lot lot lot easier. 

Fixes #496 as a treat.

> [!Note]
> I haven't made the toggles for user/other custom css themes for technical reasons. It's currently working and ready to merge but will be expanded in further PRs.

## Before

Does not exist

## After

Yippee! Yay!!

<img width="789" height="425" alt="image" src="https://github.com/user-attachments/assets/419d864a-7e20-4696-9e68-6a5d53bebb15" />

Menu contents

<img width="853" height="353" alt="image" src="https://github.com/user-attachments/assets/e597f5fe-84c6-40da-a3b1-173ba5e957bd" />

Extra settings

<img width="791" height="276" alt="image" src="https://github.com/user-attachments/assets/5b0c129c-3134-4dc7-a6cd-17c42c76e6de" />


Oh I also added bold highlighting to your theme for fun

<img width="133" height="183" alt="image" src="https://github.com/user-attachments/assets/5ce0b299-13eb-4067-882e-f42d0ad60420" />